### PR TITLE
Test out better handling of SSH disconnects

### DIFF
--- a/pioreactor/background_jobs/base.py
+++ b/pioreactor/background_jobs/base.py
@@ -510,7 +510,8 @@ class _BackgroundJob(metaclass=PostInitCaller):
             # keyboard interrupt
             append_signal_handler(signal.SIGINT, disconnect_gracefully)
 
-            # NOHUP is not included here, as it prevents tools like nohup working: https://unix.stackexchange.com/a/261631
+            # ssh closes
+            append_signal_handler(signal.SIGHUP, disconnect_gracefully)
 
         self._blocking_event = threading.Event()
 


### PR DESCRIPTION
one problem, related to #220, is when the ssh terminal disconnects and jobs are not disconnected gracefully. I think that with the new stack-handler code, the job will disconnect correctly, and then exit python

- [x] run a job from the command line, without `nohup`, and kill the terminal. We should see the job disconnect successfully.
- [x] run a job from the cli, with nohup, and disconnect from SSH. The job should persit. 
- [x] `pio kill <job>` still works.
- [x] Jobs can still be run and stopped from the UI