### PR TITLE
in tests, the logger's handlers were not being cleanup up, so it kept…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,4 +55,4 @@ jobs:
            EOT
 
       - name: Run tests
-        run: pytest pioreactor/tests/ -vv --timeout 600
+        run: pytest pioreactor/tests/ -vv --timeout 600 --random-order

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,4 +55,4 @@ jobs:
            EOT
 
       - name: Run tests
-        run: pytest pioreactor/tests/ -vv --timeout 120
+        run: pytest pioreactor/tests/ -vv --timeout 600

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,8 @@ jobs:
            import click
            from pioreactor.background_jobs.base import BackgroundJob
 
+           __plugin_version__ = "0.0.1"
+
            class ExamplePlugin(BackgroundJob):
 
               def __init__(self):

--- a/pioreactor/actions/pump.py
+++ b/pioreactor/actions/pump.py
@@ -49,7 +49,7 @@ def pump(
         "alt_media": "add_alt_media",
         "waste": "remove_waste",
     }[pump_name]
-    logger = create_logger(action_name)
+    logger = create_logger(action_name, experiment=experiment, unit=unit)
     with utils.publish_ready_to_disconnected_state(
         unit, experiment, action_name
     ) as state:
@@ -115,7 +115,7 @@ def pump(
 
         try:
 
-            pwm = PWM(GPIO_PIN, calibration["hz"])
+            pwm = PWM(GPIO_PIN, calibration["hz"], experiment=experiment, unit=unit)
             pwm.lock()
 
             with catchtime() as delta_time:

--- a/pioreactor/actions/remove_waste.py
+++ b/pioreactor/actions/remove_waste.py
@@ -19,7 +19,6 @@ def remove_waste(
     calibration: Optional[dict] = None,
     continuously: bool = False,
 ) -> float:
-
     pump_name = "waste"
     return pump(
         unit,

--- a/pioreactor/automations/dosing/continuous_cycle.py
+++ b/pioreactor/automations/dosing/continuous_cycle.py
@@ -33,7 +33,7 @@ class ContinuousCycle(DosingAutomation):
     def __init__(self, duty_cycle: float = 100.0, hz: float = 150.0, **kwargs) -> None:
         super(ContinuousCycle, self).__init__(**kwargs)
         pin = PWM_TO_PIN[config.get("PWM_reverse", "media")]
-        self.pwm = PWM(pin, hz)
+        self.pwm = PWM(pin, hz, unit=self.unit, experiment=self.experiment)
         self.duty_cycle = duty_cycle
 
     def set_duty_cycle(self, new_dc: float) -> None:

--- a/pioreactor/background_jobs/base.py
+++ b/pioreactor/background_jobs/base.py
@@ -129,7 +129,7 @@ class _BackgroundJob(metaclass=PostInitCaller):
     >     ...
     >
 
-    This will gracefully disconnect and cleanup the job, provided you clean up in the `on_disconnect` function.
+    This will gracefully disconnect and cleanup the job, provided you clean up in the `on_disconnected` function.
 
     2. Clean up yourself. The following is not recommended as it does not cleanup connections and state even after the function exits:
 
@@ -235,7 +235,17 @@ class _BackgroundJob(metaclass=PostInitCaller):
         self.sub_client = self.create_sub_client()
 
         self.set_up_exit_protocol()
-        self.check_published_settings()
+
+        try:
+            # this is one function in the __init__ that we may delibratily raise an error
+            # if we do raise an error, the class needs to be cleaned up correctly
+            # (hence the _cleanup bit, don't use set_state, as it will no-op since we are already in state DISCONNECTED)
+            # but we still raise the error afterwards.
+            self.check_published_settings()
+        except ValueError as e:
+            self._cleanup()
+            raise e
+
         self.publish_settings_to_broker()
         self.start_general_passive_listeners()
 
@@ -582,6 +592,23 @@ class _BackgroundJob(metaclass=PostInitCaller):
         self.log_state(self.state)
         pass
 
+    def _cleanup(self):
+        # Explictly cleanup resources...
+
+        # clean up logger handlers
+        while len(self.logger.handlers) > 0:
+            handler = self.logger.handlers[0]
+            handler.close()
+            self.logger.removeHandler(handler)
+
+        # disconnect from MQTT
+        self.sub_client.loop_stop()
+        self.sub_client.disconnect()
+
+        # this HAS to happen last, because this contains our publishing client
+        self.pub_client.loop_stop()  # pretty sure this doesn't close the thread if in a thread: https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/client.py#L1835
+        self.pub_client.disconnect()
+
     def disconnected(self) -> None:
         # set state to disconnect
         # call this first to make sure that it gets published to the broker.
@@ -608,12 +635,7 @@ class _BackgroundJob(metaclass=PostInitCaller):
 
         self.log_state(self.state)
 
-        self.sub_client.loop_stop()
-        self.sub_client.disconnect()
-
-        # this HAS to happen last, because this contains our publishing client
-        self.pub_client.loop_stop()  # pretty sure this doesn't close the thread if in a thread: https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/client.py#L1835
-        self.pub_client.disconnect()
+        self._cleanup()
 
     def publish_settings_to_broker(self) -> None:
         # this follows some of the Homie convention: https://homieiot.github.io/specification/

--- a/pioreactor/background_jobs/base.py
+++ b/pioreactor/background_jobs/base.py
@@ -323,7 +323,7 @@ class _BackgroundJob(metaclass=PostInitCaller):
         for setting, properties in self.published_settings.items():
             # look for extra properties
             if not all_properties.issuperset(properties.keys()):
-                self.logger.warning(f"Found extra property in setting {setting}.")
+                raise ValueError(f"Found extra property in setting {setting}.")
 
             # look for missing properties
             if not set(properties.keys()).issuperset(necessary_properies):

--- a/pioreactor/background_jobs/stirring.py
+++ b/pioreactor/background_jobs/stirring.py
@@ -233,7 +233,7 @@ class Stirrer(BackgroundJob):
             raise exc.HardwareNotFoundError("Heating PCB must be present to measure RPM.")
 
         pin = hardware.PWM_TO_PIN[config.get("PWM_reverse", "stirring")]
-        self.pwm = PWM(pin, hertz)
+        self.pwm = PWM(pin, hertz, unit=unit, experiment=experiment)
         self.pwm.lock()
 
         self.target_rpm = target_rpm

--- a/pioreactor/background_jobs/temperature_control.py
+++ b/pioreactor/background_jobs/temperature_control.py
@@ -326,7 +326,7 @@ class TemperatureController(BackgroundJob):
         hertz = 1
         pin = PWM_TO_PIN[HEATER_PWM_TO_PIN]
         pin = PWM_TO_PIN[config.get("PWM_reverse", "heating")]  # TODO: remove this.
-        pwm = PWM(pin, hertz)
+        pwm = PWM(pin, hertz, unit=self.unit, experiment=self.experiment)
         pwm.start(0)
         return pwm
 

--- a/pioreactor/logging.py
+++ b/pioreactor/logging.py
@@ -1,21 +1,24 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
-from logging import handlers, Logger
+from logging import handlers
+from logging import Logger
 from typing import Optional
+
+import colorlog
 from json_log_formatter import JSONFormatter  # type: ignore
 from paho.mqtt.client import Client  # type: ignore
-import colorlog
 
-from pioreactor.pubsub import create_client, publish_to_pioreactor_cloud
-from pioreactor.whoami import (
-    get_unit_name,
-    am_I_active_worker,
-    UNIVERSAL_EXPERIMENT,
-    get_latest_experiment_name,
-    get_uuid,
-)
 from pioreactor.config import config
+from pioreactor.pubsub import create_client
+from pioreactor.pubsub import publish_to_pioreactor_cloud
 from pioreactor.utils.timing import current_utc_time
+from pioreactor.whoami import am_I_active_worker
+from pioreactor.whoami import get_latest_experiment_name
+from pioreactor.whoami import get_unit_name
+from pioreactor.whoami import get_uuid
+from pioreactor.whoami import UNIVERSAL_EXPERIMENT
 
 logging.raiseExceptions = False
 
@@ -123,7 +126,9 @@ def create_logger(
     if (pub_client is None) and to_mqtt:
         import uuid
 
-        pub_client = create_client(client_id=f"{unit}-logging-{uuid.uuid1()}")
+        pub_client = create_client(
+            client_id=f"{unit}-{experiment}-logging-{uuid.uuid1()}"
+        )
 
     # file handler
     file_handler = handlers.WatchedFileHandler(config["logging"]["log_file"])

--- a/pioreactor/tests/test_background_job.py
+++ b/pioreactor/tests/test_background_job.py
@@ -14,7 +14,6 @@ from pioreactor.pubsub import subscribe
 from pioreactor.pubsub import subscribe_and_callback
 from pioreactor.types import MQTTMessage
 from pioreactor.utils import local_intermittent_storage
-from pioreactor.whoami import get_latest_experiment_name
 from pioreactor.whoami import get_unit_name
 from pioreactor.whoami import UNIVERSAL_EXPERIMENT
 
@@ -26,7 +25,7 @@ def pause() -> None:
 
 def test_states() -> None:
     unit = get_unit_name()
-    exp = get_latest_experiment_name()
+    exp = "test_states"
 
     bj = BackgroundJob(job_name="job", unit=unit, experiment=exp)
     pause()
@@ -78,8 +77,8 @@ def test_watchdog_will_try_to_fix_lost_job() -> None:
 def test_jobs_connecting_and_disconnecting_will_still_log_to_mqtt() -> None:
     # see note in base.py about create_logger
 
-    unit: str = get_unit_name()
-    exp: str = get_latest_experiment_name()
+    unit = get_unit_name()
+    exp = "test_jobs_connecting_and_disconnecting_will_still_log_to_mqtt"
 
     results = []
 
@@ -117,6 +116,7 @@ def test_error_in_subscribe_and_callback_is_logged() -> None:
             print(1 / 0)
 
     error_logs = []
+    experiment = "test_error_in_subscribe_and_callback_is_logged"
 
     def collect_error_logs(msg: MQTTMessage) -> None:
         if "ERROR" in msg.payload.decode():
@@ -124,12 +124,10 @@ def test_error_in_subscribe_and_callback_is_logged() -> None:
 
     subscribe_and_callback(
         collect_error_logs,
-        f"pioreactor/{get_unit_name()}/{get_latest_experiment_name()}/logs/app",
+        f"pioreactor/{get_unit_name()}/{experiment}/logs/app",
     )
 
-    with TestJob(
-        job_name="job", unit=get_unit_name(), experiment=get_latest_experiment_name()
-    ):
+    with TestJob(job_name="job", unit=get_unit_name(), experiment=experiment):
         publish("pioreactor/testing/subscription", "test")
         pause()
         pause()
@@ -147,15 +145,16 @@ def test_what_happens_when_an_error_occurs_in_init_with_no_catch() -> None:
             1 / 0  # we should try to catch this, and do a disconnect as well
 
     state = []
-    publish("pioreactor/unit/exp/testjob/$state", None, retain=True)
+    exp = "test_what_happens_when_an_error_occurs_in_init_with_no_catch"
+    publish(f"pioreactor/unit/{exp}/testjob/$state", None, retain=True)
 
     def update_state(msg: MQTTMessage) -> None:
         state.append(msg.payload.decode())
 
-    subscribe_and_callback(update_state, "pioreactor/unit/exp/testjob/$state")
+    subscribe_and_callback(update_state, f"pioreactor/unit/{exp}/testjob/$state")
 
     with pytest.raises(ZeroDivisionError):
-        with TestJob(unit="unit", experiment="exp"):
+        with TestJob(unit="unit", experiment=exp):
             pass
 
     time.sleep(0.25)
@@ -175,16 +174,17 @@ def test_what_happens_when_an_error_occurs_in_init_but_we_catch_and_disconnect()
                 self.set_state("disconnected")
                 raise e
 
-    publish("pioreactor/unit/exp/testjob/$state", None, retain=True)
+    exp = "test_what_happens_when_an_error_occurs_in_init_but_we_catch_and_disconnect"
+    publish(f"pioreactor/unit/{exp}/testjob/$state", None, retain=True)
     state = []
 
     def update_state(msg: MQTTMessage) -> None:
         state.append(msg.payload.decode())
 
-    subscribe_and_callback(update_state, "pioreactor/unit/exp/testjob/$state")
+    subscribe_and_callback(update_state, f"pioreactor/unit/{exp}/testjob/$state")
 
     with pytest.raises(ZeroDivisionError):
-        with TestJob(unit="unit", experiment="exp"):
+        with TestJob(unit="unit", experiment=exp):
             pass
 
     pause()
@@ -226,7 +226,7 @@ def test_state_transition_callbacks() -> None:
         def on_init_to_ready(self) -> None:
             self.called_on_init_to_ready = True
 
-    unit, exp = get_unit_name(), get_latest_experiment_name()
+    unit, exp = get_unit_name(), "test_state_transition_callbacks"
     with TestJob(unit, exp) as tj:
         assert tj.called_on_init
         assert tj.called_on_init_to_ready
@@ -262,6 +262,7 @@ def test_bad_key_in_published_settings() -> None:
             super(TestJob, self).__init__(*args, **kwargs)
 
     warning_logs = []
+    exp = "test_bad_key_in_published_settings"
 
     def collect_warning_logs(msg: MQTTMessage) -> None:
         if "WARNING" in msg.payload.decode():
@@ -269,12 +270,10 @@ def test_bad_key_in_published_settings() -> None:
 
     subscribe_and_callback(
         collect_warning_logs,
-        f"pioreactor/{get_unit_name()}/{get_latest_experiment_name()}/logs/app",
+        f"pioreactor/{get_unit_name()}/{exp}/logs/app",
     )
 
-    with TestJob(
-        job_name="job", unit=get_unit_name(), experiment=get_latest_experiment_name()
-    ):
+    with TestJob(job_name="job", unit=get_unit_name(), experiment=exp):
         pause()
         pause()
         assert len(warning_logs) > 0
@@ -295,9 +294,12 @@ def test_bad_setting_name_in_published_settings() -> None:
             super(TestJob, self).__init__(*args, **kwargs)
 
     with pytest.raises(ValueError):
-        TestJob(
-            job_name="job", unit=get_unit_name(), experiment=get_latest_experiment_name()
+        t = TestJob(
+            job_name="job",
+            unit=get_unit_name(),
+            experiment="test_bad_setting_name_in_published_settings",
         )
+        t.set_state(t.DISCONNECTED)
 
 
 def test_editing_readonly_attr_via_mqtt() -> None:
@@ -311,21 +313,21 @@ def test_editing_readonly_attr_via_mqtt() -> None:
         }
 
     warning_logs = []
+    exp = "test_editing_readonly_attr_via_mqtt"
 
     def collect_logs(msg: MQTTMessage) -> None:
+        print(msg.payload.decode())
         if "readonly" in msg.payload.decode():
             warning_logs.append(msg)
 
     subscribe_and_callback(
         collect_logs,
-        f"pioreactor/{get_unit_name()}/{get_latest_experiment_name()}/logs/app",
+        f"pioreactor/{get_unit_name()}/{exp}/logs/app",
     )
 
-    with TestJob(
-        job_name="job", unit=get_unit_name(), experiment=get_latest_experiment_name()
-    ):
+    with TestJob(job_name="job", unit=get_unit_name(), experiment=exp):
         publish(
-            f"pioreactor/{get_unit_name()}/{get_latest_experiment_name()}/job/readonly_attr/set",
+            f"pioreactor/{get_unit_name()}/{exp}/job/readonly_attr/set",
             1.0,
         )
         pause()
@@ -349,22 +351,22 @@ def test_persist_in_published_settings() -> None:
             self.persist_this = "persist_this"
             self.dont_persist_this = "dont_persist_this"
 
-    with TestJob(
-        job_name="test_job", unit=get_unit_name(), experiment=get_latest_experiment_name()
-    ):
+    exp = "test_persist_in_published_settings"
+
+    with TestJob(job_name="test_job", unit=get_unit_name(), experiment=exp):
         pause()
         pause()
 
     pause()
     msg = subscribe(
-        f"pioreactor/{get_unit_name()}/{get_latest_experiment_name()}/test_job/persist_this",
+        f"pioreactor/{get_unit_name()}/{exp}/test_job/persist_this",
         timeout=2,
     )
     assert msg is not None
     assert msg.payload.decode() == "persist_this"
 
     msg = subscribe(
-        f"pioreactor/{get_unit_name()}/{get_latest_experiment_name()}/test_job/dont_persist_this",
+        f"pioreactor/{get_unit_name()}/{exp}/test_job/dont_persist_this",
         timeout=2,
     )
     assert msg is None
@@ -387,6 +389,6 @@ def test_sys_exit_does_exit() -> None:
 
     with pytest.raises(SystemExit):
         with TestJob(
-            unit=get_unit_name(), experiment=get_latest_experiment_name(), job_name="job"
+            unit=get_unit_name(), experiment="test_sys_exit_does_exit", job_name="job"
         ) as t:
             t.call_all_i_do_is_exit()

--- a/pioreactor/tests/test_background_job.py
+++ b/pioreactor/tests/test_background_job.py
@@ -261,23 +261,10 @@ def test_bad_key_in_published_settings() -> None:
         def __init__(self, *args, **kwargs) -> None:
             super(TestJob, self).__init__(*args, **kwargs)
 
-    warning_logs = []
     exp = "test_bad_key_in_published_settings"
-
-    def collect_warning_logs(msg: MQTTMessage) -> None:
-        if "WARNING" in msg.payload.decode():
-            warning_logs.append(msg)
-
-    subscribe_and_callback(
-        collect_warning_logs,
-        f"pioreactor/{get_unit_name()}/{exp}/logs/app",
-    )
-
-    with TestJob(job_name="job", unit=get_unit_name(), experiment=exp):
-        pause()
-        pause()
-        assert len(warning_logs) > 0
-        assert "Found extra property" in warning_logs[0].payload.decode()
+    with pytest.raises(ValueError):
+        with TestJob(job_name="job", unit=get_unit_name(), experiment=exp):
+            pass
 
 
 def test_bad_setting_name_in_published_settings() -> None:
@@ -293,13 +280,10 @@ def test_bad_setting_name_in_published_settings() -> None:
         def __init__(self, *args, **kwargs) -> None:
             super(TestJob, self).__init__(*args, **kwargs)
 
+    exp = "test_bad_setting_name_in_published_settings"
     with pytest.raises(ValueError):
-        t = TestJob(
-            job_name="job",
-            unit=get_unit_name(),
-            experiment="test_bad_setting_name_in_published_settings",
-        )
-        t.set_state(t.DISCONNECTED)
+        with TestJob(job_name="job", unit=get_unit_name(), experiment=exp):
+            pass
 
 
 def test_editing_readonly_attr_via_mqtt() -> None:

--- a/pioreactor/tests/test_cli.py
+++ b/pioreactor/tests/test_cli.py
@@ -19,8 +19,21 @@ def test_run():
     assert result.exit_code == 0
 
 
-def test_plugin_is_available():
+def test_plugin_is_available_to_run():
+    runner = CliRunner()
+    result = runner.invoke(pio, ["run", "example_plugin"])
+    assert result.exit_code == 0
+
+
+def test_plugin_is_able_to_be_run():
 
     runner = CliRunner()
     result = runner.invoke(pio, ["run", "example_plugin"])
     assert result.exit_code == 0
+
+
+def test_list_plugins():
+
+    runner = CliRunner()
+    result = runner.invoke(pio, ["list-plugins"])
+    assert "example_plugin==0.0.1" in result.output

--- a/pioreactor/tests/test_dosing_control.py
+++ b/pioreactor/tests/test_dosing_control.py
@@ -682,12 +682,11 @@ def test_execute_io_action_outputs_will_be_null_if_calibration_is_not_defined() 
         del cache["media_ml_calibration"]
         del cache["alt_media_ml_calibration"]
 
-    ca = DosingAutomation(unit=unit, experiment=experiment, skip_first_run=True)
-    result = ca.execute_io_action(media_ml=1.0, alt_media_ml=1.0, waste_ml=2.0)
-    assert result[0] == 0
-    assert result[1] == 0.0
-    assert result[2] == 2.0
-    ca.set_state(ca.DISCONNECTED)
+    with DosingAutomation(unit=unit, experiment=experiment, skip_first_run=True) as ca:
+        result = ca.execute_io_action(media_ml=1.0, alt_media_ml=1.0, waste_ml=2.0)
+        assert result[0] == 0
+        assert result[1] == 0.0
+        assert result[2] == 2.0
 
     # add back to cache
     with local_persistant_storage("pump_calibration") as cache:

--- a/pioreactor/tests/test_dosing_control.py
+++ b/pioreactor/tests/test_dosing_control.py
@@ -17,12 +17,10 @@ from pioreactor.automations.dosing.silent import Silent
 from pioreactor.automations.dosing.turbidostat import Turbidostat
 from pioreactor.background_jobs.dosing_control import DosingController
 from pioreactor.utils import local_persistant_storage
-from pioreactor.whoami import get_latest_experiment_name
 from pioreactor.whoami import get_unit_name
 
 
 unit = get_unit_name()
-experiment = get_latest_experiment_name()
 
 
 def pause() -> None:
@@ -44,6 +42,7 @@ def setup_function() -> None:
 
 
 def test_silent_automation() -> None:
+    experiment = "test_silent_automation"
     with Silent(volume=None, duration=60, unit=unit, experiment=experiment) as algo:
         pause()
         pubsub.publish(
@@ -70,6 +69,7 @@ def test_silent_automation() -> None:
 
 
 def test_turbidostat_automation() -> None:
+    experiment = "test_turbidostat_automation"
     target_od = 1.0
     with Turbidostat(
         target_od=target_od, duration=60, volume=0.25, unit=unit, experiment=experiment
@@ -121,7 +121,7 @@ def test_turbidostat_automation() -> None:
 
 
 def test_pid_turbidostat_automation() -> None:
-
+    experiment = "test_pid_turbidostat_automation"
     target_od = 2.4
     with PIDTurbidostat(
         target_od=target_od, duration=20, unit=unit, experiment=experiment
@@ -153,6 +153,7 @@ def test_pid_turbidostat_automation() -> None:
 
 
 def test_morbidostat_automation() -> None:
+    experiment = "test_morbidostat_automation"
     pubsub.publish(
         f"pioreactor/{unit}/{experiment}/growth_rate_calculating/growth_rate",
         None,
@@ -238,6 +239,7 @@ def test_morbidostat_automation() -> None:
 
 
 def test_pid_morbidostat_automation() -> None:
+    experiment = "test_pid_morbidostat_automation"
     target_growth_rate = 0.09
     algo = PIDMorbidostat(
         target_od=1.0,
@@ -291,7 +293,7 @@ def test_pid_morbidostat_automation() -> None:
 
 
 def test_changing_morbidostat_parameters_over_mqtt() -> None:
-
+    experiment = "test_changing_morbidostat_parameters_over_mqtt"
     target_growth_rate = 0.05
     algo = PIDMorbidostat(
         target_growth_rate=target_growth_rate,
@@ -314,7 +316,7 @@ def test_changing_morbidostat_parameters_over_mqtt() -> None:
 
 
 def test_changing_turbidostat_params_over_mqtt() -> None:
-
+    experiment = "test_changing_turbidostat_params_over_mqtt"
     og_volume = 0.5
     og_target_od = 1.0
     algo = Turbidostat(
@@ -362,7 +364,7 @@ def test_changing_turbidostat_params_over_mqtt() -> None:
 
 
 def test_changing_parameters_over_mqtt_with_unknown_parameter() -> None:
-
+    experiment = "test_changing_parameters_over_mqtt_with_unknown_parameter"
     with DosingAutomation(
         target_growth_rate=0.05,
         target_od=1.0,
@@ -391,7 +393,7 @@ def test_changing_parameters_over_mqtt_with_unknown_parameter() -> None:
 
 
 def test_pause_in_dosing_automation() -> None:
-
+    experiment = "test_pause_in_dosing_automation"
     with DosingAutomation(
         target_growth_rate=0.05,
         target_od=1.0,
@@ -414,7 +416,7 @@ def test_pause_in_dosing_automation() -> None:
 
 
 def test_pause_in_dosing_control_also_pauses_automation() -> None:
-
+    experiment = "test_pause_in_dosing_control_also_pauses_automation"
     algo = DosingController(
         "turbidostat",
         target_od=1.0,
@@ -439,6 +441,7 @@ def test_pause_in_dosing_control_also_pauses_automation() -> None:
 
 
 def test_old_readings_will_not_execute_io() -> None:
+    experiment = "test_old_readings_will_not_execute_io"
     algo = DosingAutomation(
         target_growth_rate=0.05,
         target_od=1.0,
@@ -459,6 +462,7 @@ def test_old_readings_will_not_execute_io() -> None:
 
 
 def test_throughput_calculator() -> None:
+    experiment = "test_throughput_calculator"
     with local_persistant_storage("media_throughput") as c:
         c[experiment] = "0.0"
 
@@ -531,7 +535,7 @@ def test_throughput_calculator() -> None:
 
 
 def test_throughput_calculator_restart() -> None:
-
+    experiment = "test_throughput_calculator_restart"
     with local_persistant_storage("media_throughput") as c:
         c[experiment] = str(1.0)
 
@@ -552,7 +556,7 @@ def test_throughput_calculator_restart() -> None:
 
 
 def test_throughput_calculator_manual_set() -> None:
-
+    experiment = "test_throughput_calculator_manual_set"
     with local_persistant_storage("media_throughput") as c:
         c[experiment] = str(1.0)
 
@@ -586,6 +590,7 @@ def test_throughput_calculator_manual_set() -> None:
 
 
 def test_execute_io_action() -> None:
+    experiment = "test_execute_io_action"
     with local_persistant_storage("media_throughput") as c:
         c[experiment] = "0.0"
 
@@ -619,6 +624,7 @@ def test_execute_io_action() -> None:
 
 
 def test_execute_io_action2() -> None:
+    experiment = "test_execute_io_action2"
     with local_persistant_storage("media_throughput") as c:
         c[experiment] = "0.0"
 
@@ -640,6 +646,7 @@ def test_execute_io_action2() -> None:
 
 def test_execute_io_action_outputs1() -> None:
     # regression test
+    experiment = "test_execute_io_action_outputs1"
     with local_persistant_storage("media_throughput") as c:
         c[experiment] = "0.0"
 
@@ -659,6 +666,9 @@ def test_execute_io_action_outputs1() -> None:
 
 def test_execute_io_action_outputs_will_be_null_if_calibration_is_not_defined() -> None:
     # regression test
+    experiment = (
+        "test_execute_io_action_outputs_will_be_null_if_calibration_is_not_defined"
+    )
     with local_persistant_storage("media_throughput") as c:
         c[experiment] = "0.0"
 
@@ -687,6 +697,7 @@ def test_execute_io_action_outputs_will_be_null_if_calibration_is_not_defined() 
 
 def test_execute_io_action_outputs_will_shortcut_if_disconnected() -> None:
     # regression test
+    experiment = "test_execute_io_action_outputs_will_shortcut_if_disconnected"
     with local_persistant_storage("media_throughput") as c:
         c[experiment] = "0.0"
 
@@ -705,6 +716,7 @@ def test_execute_io_action_outputs_will_shortcut_if_disconnected() -> None:
 
 
 def test_duration_and_timer() -> None:
+    experiment = "test_duration_and_timer"
     algo = PIDMorbidostat(
         target_od=1.0,
         target_growth_rate=0.01,
@@ -740,6 +752,7 @@ def test_duration_and_timer() -> None:
 
 
 def test_changing_duration_over_mqtt() -> None:
+    experiment = "test_changing_duration_over_mqtt"
     with PIDMorbidostat(
         target_od=1.0,
         target_growth_rate=0.01,
@@ -769,6 +782,7 @@ def test_changing_duration_over_mqtt() -> None:
 
 
 def test_changing_duration_over_mqtt_will_start_next_run_earlier() -> None:
+    experiment = "test_changing_duration_over_mqtt_will_start_next_run_earlier"
     with PIDMorbidostat(
         target_od=1.0,
         target_growth_rate=0.01,
@@ -799,7 +813,7 @@ def test_changing_duration_over_mqtt_will_start_next_run_earlier() -> None:
 
 
 def test_changing_algo_over_mqtt_solo() -> None:
-
+    experiment = "test_changing_algo_over_mqtt_solo"
     with DosingController(
         "turbidostat",
         target_od=1.0,
@@ -821,7 +835,7 @@ def test_changing_algo_over_mqtt_solo() -> None:
 
 
 def test_changing_algo_over_mqtt_when_it_fails_will_rollback() -> None:
-
+    experiment = "test_changing_algo_over_mqtt_when_it_fails_will_rollback"
     with DosingController(
         "turbidostat",
         target_od=1.0,
@@ -847,6 +861,7 @@ def test_changing_algo_over_mqtt_when_it_fails_will_rollback() -> None:
 
 
 def test_changing_algo_over_mqtt_will_not_produce_two_dosing_jobs() -> None:
+    experiment = "test_changing_algo_over_mqtt_will_not_produce_two_dosing_jobs"
     with local_persistant_storage("media_throughput") as c:
         c[experiment] = "0.0"
 
@@ -898,6 +913,7 @@ def test_changing_algo_over_mqtt_will_not_produce_two_dosing_jobs() -> None:
 
 
 def test_changing_algo_over_mqtt_with_wrong_type_is_okay() -> None:
+    experiment = "test_changing_algo_over_mqtt_with_wrong_type_is_okay"
     with local_persistant_storage("media_throughput") as c:
         c[experiment] = "0.0"
 
@@ -925,7 +941,7 @@ def test_changing_algo_over_mqtt_with_wrong_type_is_okay() -> None:
 
 
 def test_disconnect_cleanly() -> None:
-
+    experiment = "test_disconnect_cleanly"
     algo = DosingController(
         "turbidostat",
         target_od=1.0,
@@ -944,6 +960,8 @@ def test_disconnect_cleanly() -> None:
 
 
 def test_custom_class_will_register_and_run() -> None:
+    experiment = "test_custom_class_will_register_and_run"
+
     class NaiveTurbidostat(DosingAutomation):
 
         automation_name = "naive_turbidostat"
@@ -965,13 +983,13 @@ def test_custom_class_will_register_and_run() -> None:
         target_od=2.0,
         duration=10,
         unit=get_unit_name(),
-        experiment=get_latest_experiment_name(),
+        experiment=experiment,
     )
     algo.set_state(algo.DISCONNECTED)
 
 
 def test_what_happens_when_no_od_data_is_coming_in() -> None:
-
+    experiment = "test_what_happens_when_no_od_data_is_coming_in"
     pubsub.publish(
         f"pioreactor/{unit}/{experiment}/growth_rate_calculating/growth_rate",
         None,
@@ -993,6 +1011,7 @@ def test_what_happens_when_no_od_data_is_coming_in() -> None:
 
 
 def test_changing_duty_cycle_over_mqtt() -> None:
+    experiment = "test_changing_duty_cycle_over_mqtt"
     with ContinuousCycle(unit=unit, experiment=experiment) as algo:
 
         assert algo.duty_cycle == 100
@@ -1004,7 +1023,6 @@ def test_changing_duty_cycle_over_mqtt() -> None:
 
 
 def test_AltMediaCalculator() -> None:
-
     ac = AltMediaCalculator()
 
     data = {"volume_change": 1.0, "event": "add_media"}

--- a/pioreactor/tests/test_led_intensity.py
+++ b/pioreactor/tests/test_led_intensity.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 # test_led_intensity
+from __future__ import annotations
+
 import pytest
-from pioreactor.actions.led_intensity import (
-    lock_leds_temporarily,
-    led_intensity,
-    LedChannel,
-)
-from pioreactor.whoami import get_unit_name, get_latest_experiment_name
+
+from pioreactor.actions.led_intensity import led_intensity
+from pioreactor.actions.led_intensity import LedChannel
+from pioreactor.actions.led_intensity import lock_leds_temporarily
 from pioreactor.utils import local_intermittent_storage
+from pioreactor.whoami import get_unit_name
 
 
 def test_lock_will_prevent_led_from_updating() -> None:
@@ -15,7 +16,7 @@ def test_lock_will_prevent_led_from_updating() -> None:
     channel: LedChannel = "A"
 
     unit = get_unit_name()
-    exp = get_latest_experiment_name()
+    exp = "test_lock_will_prevent_led_from_updating"
 
     assert led_intensity(channels=channel, intensities=20, unit=unit, experiment=exp)
 
@@ -31,7 +32,9 @@ def test_lock_will_prevent_led_from_updating() -> None:
 def test_lock_will_prevent_led_from_updating_single_channel_but_not_others_passed_in() -> None:
 
     unit = get_unit_name()
-    exp = get_latest_experiment_name()
+    exp = (
+        "test_lock_will_prevent_led_from_updating_single_channel_but_not_others_passed_in"
+    )
 
     assert led_intensity(
         channels=["A", "B"], intensities=[20, 20], unit=unit, experiment=exp
@@ -53,7 +56,7 @@ def test_lock_will_prevent_led_from_updating_single_channel_but_not_others_passe
 
 def test_error_is_thrown_if_lengths_are_wrong() -> None:
     unit = get_unit_name()
-    exp = get_latest_experiment_name()
+    exp = "test_error_is_thrown_if_lengths_are_wrong"
 
     with pytest.raises(ValueError):
         led_intensity(channels=["A", "B"], intensities=[20], unit=unit, experiment=exp)
@@ -69,7 +72,7 @@ def test_local_cache_is_updated() -> None:
     channel: LedChannel = "B"
 
     unit = get_unit_name()
-    exp = get_latest_experiment_name()
+    exp = "test_local_cache_is_updated"
 
     assert led_intensity(channels=channel, intensities=20, unit=unit, experiment=exp)
 

--- a/pioreactor/tests/test_od_reading.py
+++ b/pioreactor/tests/test_od_reading.py
@@ -162,15 +162,18 @@ def test_ADC_picks_to_correct_freq_even_if_slight_noise_in_freq() -> None:
 
 def test_error_thrown_if_wrong_angle() -> None:
     with pytest.raises(ValueError):
-        start_od_reading("100", "135", fake_data=True)  # type: ignore
+        start_od_reading("100", "135", fake_data=True, experiment="test_error_thrown_if_wrong_angle")  # type: ignore
 
     with pytest.raises(ValueError):
-        start_od_reading("100", None, fake_data=True)  # type: ignore
+        start_od_reading("100", None, fake_data=True, experiment="test_error_thrown_if_wrong_angle")  # type: ignore
 
     with pytest.raises(ValueError):
-        start_od_reading("135", "99", fake_data=True)  # type: ignore
+        start_od_reading("135", "99", fake_data=True, experiment="test_error_thrown_if_wrong_angle")  # type: ignore
 
     with pytest.raises(ValueError):
-        start_od_reading("100", "REF", fake_data=True)  # type: ignore
+        start_od_reading("100", "REF", fake_data=True, experiment="test_error_thrown_if_wrong_angle")  # type: ignore
 
-    start_od_reading("135", "90", fake_data=True)
+    st = start_od_reading(
+        "135", "90", fake_data=True, experiment="test_error_thrown_if_wrong_angle"
+    )
+    st.set_state(st.DISCONNECTED)

--- a/pioreactor/tests/test_temperature_control.py
+++ b/pioreactor/tests/test_temperature_control.py
@@ -9,11 +9,9 @@ from pioreactor.automations.temperature import ConstantDutyCycle
 from pioreactor.automations.temperature import Silent
 from pioreactor.automations.temperature import Stable
 from pioreactor.background_jobs import temperature_control
-from pioreactor.whoami import get_latest_experiment_name
 from pioreactor.whoami import get_unit_name
 
 unit = get_unit_name()
-experiment = get_latest_experiment_name()
 
 
 def pause(n=1) -> None:
@@ -22,6 +20,7 @@ def pause(n=1) -> None:
 
 
 def test_stable_automation() -> None:
+    experiment = "test_stable_automation"
     with temperature_control.TemperatureController(
         "stable", target_temperature=50, unit=unit, experiment=experiment
     ) as algo:
@@ -46,6 +45,7 @@ def test_stable_automation() -> None:
 
 
 def test_changing_temperature_algo_over_mqtt() -> None:
+    experiment = "test_changing_temperature_algo_over_mqtt"
     pubsub.publish(
         f"pioreactor/{unit}/{experiment}/temperature_control/temperature",
         None,
@@ -69,6 +69,7 @@ def test_changing_temperature_algo_over_mqtt() -> None:
 
 
 def test_changing_temperature_algo_over_mqtt_and_then_update_params() -> None:
+    experiment = "test_changing_temperature_algo_over_mqtt_and_then_update_params"
     pubsub.publish(
         f"pioreactor/{unit}/{experiment}/temperature_control/temperature",
         None,
@@ -98,7 +99,7 @@ def test_changing_temperature_algo_over_mqtt_and_then_update_params() -> None:
 
 
 def test_heating_is_reduced_when_set_temp_is_exceeded() -> None:
-
+    experiment = "test_heating_is_reduced_when_set_temp_is_exceeded"
     with temperature_control.TemperatureController(
         "silent", unit=unit, experiment=experiment
     ) as t:
@@ -115,7 +116,9 @@ def test_heating_is_reduced_when_set_temp_is_exceeded() -> None:
 
 
 def test_stable_doesnt_fail_when_initial_target_is_less_than_initial_temperature() -> None:
-
+    experiment = (
+        "test_stable_doesnt_fail_when_initial_target_is_less_than_initial_temperature"
+    )
     with temperature_control.TemperatureController(
         "stable", unit=unit, experiment=experiment, target_temperature=20
     ) as t:
@@ -126,7 +129,7 @@ def test_stable_doesnt_fail_when_initial_target_is_less_than_initial_temperature
 
 
 def test_heating_stops_when_max_temp_is_exceeded() -> None:
-
+    experiment = "test_heating_stops_when_max_temp_is_exceeded"
     with temperature_control.TemperatureController(
         "stable",
         unit=unit,
@@ -147,7 +150,7 @@ def test_heating_stops_when_max_temp_is_exceeded() -> None:
 
 
 def test_child_cant_update_heater_when_locked() -> None:
-
+    experiment = "test_child_cant_update_heater_when_locked"
     with temperature_control.TemperatureController(
         "silent", unit=unit, experiment=experiment, eval_and_publish_immediately=False
     ) as t:
@@ -161,6 +164,7 @@ def test_child_cant_update_heater_when_locked() -> None:
 
 
 def test_constant_duty_cycle_init() -> None:
+    experiment = "test_constant_duty_cycle_init"
     pubsub.publish(
         f"pioreactor/{unit}/{experiment}/temperature_control/temperature",
         None,
@@ -177,7 +181,7 @@ def test_constant_duty_cycle_init() -> None:
 
 def test_setting_pid_control_after_startup_will_start_some_heating() -> None:
     # this test tries to replicate what a user does in the UI
-
+    experiment = "test_setting_pid_control_after_startup_will_start_some_heating"
     with temperature_control.TemperatureController(
         "stable", unit=unit, experiment=experiment, target_temperature=35
     ) as t:
@@ -188,7 +192,7 @@ def test_setting_pid_control_after_startup_will_start_some_heating() -> None:
 
 
 def test_duty_cycle_is_published_and_not_settable() -> None:
-
+    experiment = "test_duty_cycle_is_published_and_not_settable"
     dc_msgs = []
 
     def collect(msg) -> None:
@@ -196,7 +200,7 @@ def test_duty_cycle_is_published_and_not_settable() -> None:
 
     pubsub.subscribe_and_callback(
         collect,
-        f"pioreactor/{get_unit_name()}/{get_latest_experiment_name()}/temperature_control/heater_duty_cycle",
+        f"pioreactor/{unit}/{experiment}/temperature_control/heater_duty_cycle",
     )
 
     with temperature_control.TemperatureController(
@@ -213,7 +217,7 @@ def test_duty_cycle_is_published_and_not_settable() -> None:
 
         # should produce an "Unable to set heater_duty_cycle"
         pubsub.publish(
-            f"pioreactor/{get_unit_name()}/{get_latest_experiment_name()}/temperature_control/heater_duty_cycle/set",
+            f"pioreactor/{unit}/{experiment}/temperature_control/heater_duty_cycle/set",
             10,
         )
 
@@ -223,7 +227,7 @@ def test_duty_cycle_is_published_and_not_settable() -> None:
 
 
 def test_temperature_approximation1() -> None:
-
+    experiment = "test_temperature_approximation1"
     features = {
         "previous_heater_dc": 17,
         "time_series_of_temp": [
@@ -254,7 +258,7 @@ def test_temperature_approximation1() -> None:
 
 
 def test_temperature_approximation2() -> None:
-
+    experiment = "test_temperature_approximation2"
     features = {
         "previous_heater_dc": 17,
         "time_series_of_temp": [
@@ -285,7 +289,7 @@ def test_temperature_approximation2() -> None:
 
 
 def test_temperature_approximation3() -> None:
-
+    experiment = "test_temperature_approximation3"
     features = {
         "previous_heater_dc": 17,
         "time_series_of_temp": [
@@ -316,7 +320,7 @@ def test_temperature_approximation3() -> None:
 
 
 def test_temperature_approximation_if_constant() -> None:
-
+    experiment = "test_temperature_approximation_if_constant"
     features = {"previous_heater_dc": 17, "time_series_of_temp": 30 * [32.0]}
 
     with temperature_control.TemperatureController(
@@ -328,6 +332,7 @@ def test_temperature_approximation_if_constant() -> None:
 def test_temperature_approximation_even_if_very_tiny_heat_source() -> None:
     import numpy as np
 
+    experiment = "test_temperature_approximation_even_if_very_tiny_heat_source"
     features = {
         "previous_heater_dc": 14.5,
         "time_series_of_temp": list(
@@ -346,6 +351,7 @@ def test_temperature_approximation_even_if_very_tiny_heat_source() -> None:
 def test_temperature_approximation_even_if_very_large_heat_source() -> None:
     import numpy as np
 
+    experiment = "test_temperature_approximation_even_if_very_large_heat_source"
     features = {
         "previous_heater_dc": 14.5,
         "time_series_of_temp": list(
@@ -362,7 +368,7 @@ def test_temperature_approximation_even_if_very_large_heat_source() -> None:
 
 
 def test_temperature_approximation_if_dc_is_nil() -> None:
-
+    experiment = "test_temperature_approximation_if_dc_is_nil"
     features = {"previous_heater_dc": 0, "time_series_of_temp": [37.8125, 32.1875]}
 
     with temperature_control.TemperatureController(
@@ -372,7 +378,7 @@ def test_temperature_approximation_if_dc_is_nil() -> None:
 
 
 def test_temperature_control_and_stables_relationship():
-
+    experiment = "test_temperature_control_and_stables_relationship"
     with temperature_control.TemperatureController(
         "stable", unit=unit, experiment=experiment, target_temperature=30
     ) as tc:
@@ -409,4 +415,4 @@ def test_temperature_control_and_stables_relationship():
         assert tc.heater_duty_cycle == 0
         pause()
 
-        thread.join()
+        thread.join()  # this takes a while

--- a/pioreactor/tests/test_temperature_control.py
+++ b/pioreactor/tests/test_temperature_control.py
@@ -81,12 +81,13 @@ def test_changing_temperature_algo_over_mqtt_and_then_update_params() -> None:
     ) as algo:
         assert algo.automation_name == "silent"
         assert isinstance(algo.automation_job, Silent)
-
+        pause()
+        pause()
         pubsub.publish(
             f"pioreactor/{unit}/{experiment}/temperature_control/automation/set",
             '{"automation_name": "constant_duty_cycle", "duty_cycle": 25}',
         )
-        time.sleep(8)
+        time.sleep(15)
         assert algo.automation_name == "constant_duty_cycle"
         assert isinstance(algo.automation_job, ConstantDutyCycle)
         assert algo.automation_job.duty_cycle == 25

--- a/pioreactor/utils/__init__.py
+++ b/pioreactor/utils/__init__.py
@@ -116,15 +116,6 @@ class publish_ready_to_disconnected_state:
         return self
 
     def __exit__(self, *args) -> None:
-        self.client.publish(
-            f"pioreactor/{self.unit}/{self.experiment}/{self.name}/$state",
-            "disconnected",
-            qos=QOS.AT_LEAST_ONCE,
-            retain=True,
-        )
-
-        self.client.loop_stop()
-        self.client.disconnect()
 
         return
 

--- a/pioreactor/utils/pwm.py
+++ b/pioreactor/utils/pwm.py
@@ -65,9 +65,14 @@ class PWM:
     HARDWARE_PWM_CHANNELS: dict[GpioPin, int] = {12: 0, 13: 1}
 
     def __init__(
-        self, pin: GpioPin, hz: float, always_use_software: bool = False
+        self,
+        pin: GpioPin,
+        hz: float,
+        always_use_software: bool = False,
+        experiment: str = None,
+        unit: str = None,
     ) -> None:
-        self.logger = create_logger("PWM")
+        self.logger = create_logger("PWM", experiment=experiment, unit=unit)
         self.pin = pin
         self.hz = hz
 

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -3,4 +3,5 @@
 -r requirements_leader.txt
 pytest
 pytest-timeout
+pytest-random-order
 fake-rpi


### PR DESCRIPTION
… using the same MQTTHandler over and over. This was causing problems for specific tests.