### PR TITLE
pump refactor deux

### DIFF
--- a/pioreactor/actions/pump.py
+++ b/pioreactor/actions/pump.py
@@ -16,8 +16,8 @@ from configparser import NoOptionError
 from functools import partial
 from threading import Event
 from threading import Thread
-from typing import Optional
 from types import SimpleNamespace
+from typing import Optional
 
 import click
 from msgspec.json import decode
@@ -43,13 +43,14 @@ from pioreactor.whoami import get_unit_name
 
 pumping_actions = SimpleNamespace()
 
+
 def register_pump(name=None):
     def decorate(func):
         func_name = name or func.__name__
         setattr(pumping_actions, func_name, func)
         return func
-    return decorate
 
+    return decorate
 
 
 DEFAULT_PWM_CALIBRATION = structs.PumpCalibration(
@@ -67,11 +68,11 @@ DEFAULT_PWM_CALIBRATION = structs.PumpCalibration(
 )
 
 
-
 class PWMPump:
     """
     A basic class that use the builtin PWM control to control a DC-voltage peristaltic pump.
     """
+
     def __init__(
         self,
         unit: str,
@@ -313,7 +314,6 @@ register_pump("remove_waste")(partial(_pump_action, "waste"))
 register_pump("add_alt_media")(partial(_pump_action, "alt_media"))
 
 
-
 def _liquid_circulation_via_pwm_pumps(
     pump_type: str,
     duration: pt.Seconds,
@@ -356,7 +356,10 @@ def _liquid_circulation_via_pwm_pumps(
     # if we know the calibrations for each pump, we will use a different rate.
     ratio = 0.85
 
-    if waste_calibration != DEFAULT_PWM_CALIBRATION and media_calibration != DEFAULT_PWM_CALIBRATION:
+    if (
+        waste_calibration != DEFAULT_PWM_CALIBRATION
+        and media_calibration != DEFAULT_PWM_CALIBRATION
+    ):
         # provided with calibrations, we can compute if media_rate > waste_rate, which is a danger zone!
         if media_calibration.duration_ > waste_calibration.duration_:
             ratio = min(waste_calibration.duration_ / media_calibration.duration_, ratio)

--- a/pioreactor/actions/pump_calibration.py
+++ b/pioreactor/actions/pump_calibration.py
@@ -14,6 +14,7 @@ from msgspec.json import decode
 from msgspec.json import encode
 
 from pioreactor import structs
+from pioreactor import types as pt
 from pioreactor.actions.pump import pumping_actions
 from pioreactor.config import config
 from pioreactor.config import leader_address
@@ -29,7 +30,6 @@ from pioreactor.utils.timing import current_utc_datetime
 from pioreactor.whoami import get_latest_experiment_name
 from pioreactor.whoami import get_latest_testing_experiment_name
 from pioreactor.whoami import get_unit_name
-from pioreactor import types as pt
 
 
 def introduction() -> None:
@@ -248,9 +248,7 @@ def run_tests(
     )
 
     results: list[float] = []
-    durations_to_test = (
-        [min_duration] * 5  + [max_duration] * 5
-    )
+    durations_to_test = [min_duration] * 5 + [max_duration] * 5
 
     for i, duration in enumerate(durations_to_test):
         while True:
@@ -501,7 +499,9 @@ def change_current(name: str) -> None:
                 all_calibrations[name], type=structs.subclass_union(structs.PumpCalibration)
             )  # decode name from list of all names
         except KeyError as e:
-            create_logger("pump_calibration").error(f"Failed to swap. Calibration `{name}` not found.")
+            create_logger("pump_calibration").error(
+                f"Failed to swap. Calibration `{name}` not found."
+            )
             raise click.Abort()
 
     pump_type_from_new_calibration = new_calibration.pump  # retrieve the pump type
@@ -530,8 +530,6 @@ def change_current(name: str) -> None:
         )
     else:
         click.echo(f"Set {new_calibration.name} to current calibration.")
-
-
 
 
 def list_():

--- a/pioreactor/automations/dosing/base.py
+++ b/pioreactor/automations/dosing/base.py
@@ -18,9 +18,7 @@ from msgspec.json import encode
 from pioreactor import exc
 from pioreactor import structs
 from pioreactor import types as pt
-from pioreactor.actions.pump import add_alt_media
-from pioreactor.actions.pump import add_media
-from pioreactor.actions.pump import remove_waste
+from pioreactor.actions.pump import pumping_actions
 from pioreactor.automations import events
 from pioreactor.background_jobs.dosing_control import DosingController
 from pioreactor.background_jobs.subjobs import BackgroundSubJob
@@ -139,7 +137,6 @@ class AltMediaCalculator:
             current_vial_volume + total_addition
         )
 
-
 class DosingAutomationJob(BackgroundSubJob):
     """
     This is the super class that automations inherit from. The `run` function will
@@ -175,13 +172,13 @@ class DosingAutomationJob(BackgroundSubJob):
     # overwrite to use your own dosing programs.
     # interface must look like types.DosingProgram
     add_media_to_bioreactor: pt.DosingProgram = partial(
-        add_media, duration=None, calibration=None, continuously=False
+        pumping_actions.add_media, duration=None, calibration=None, continuously=False
     )
     remove_waste_from_bioreactor: pt.DosingProgram = partial(
-        remove_waste, duration=None, calibration=None, continuously=False
+        pumping_actions.remove_waste, duration=None, calibration=None, continuously=False
     )
     add_alt_media_to_bioreactor: pt.DosingProgram = partial(
-        add_alt_media, duration=None, calibration=None, continuously=False
+        pumping_actions.add_alt_media, duration=None, calibration=None, continuously=False
     )
 
     # dosing metrics that are available, and published to MQTT

--- a/pioreactor/automations/dosing/base.py
+++ b/pioreactor/automations/dosing/base.py
@@ -137,6 +137,7 @@ class AltMediaCalculator:
             current_vial_volume + total_addition
         )
 
+
 class DosingAutomationJob(BackgroundSubJob):
     """
     This is the super class that automations inherit from. The `run` function will

--- a/pioreactor/background_jobs/monitor.py
+++ b/pioreactor/background_jobs/monitor.py
@@ -484,6 +484,8 @@ class Monitor(BackgroundJob):
         # we use a thread here since we want to exit this callback without blocking it.
         # a blocked callback can disconnect from MQTT broker, prevent other callbacks, etc.
 
+        from pioreactor.actions.pump import pumping_actions
+
         import subprocess
         from shlex import (
             quote,
@@ -506,16 +508,9 @@ class Monitor(BackgroundJob):
                 kwargs=payload,
             ).start()
 
-        elif job_name in (
-            "add_media",
-            "add_alt_media",
-            "remove_waste",
-            "circulate_media",
-            "circulate_alt_media",
-        ):
-            from pioreactor.actions import pump as pump_actions
+        elif job_name in vars(pumping_actions):
 
-            pump_action = getattr(pump_actions, job_name)
+            pump_action = getattr(pumping_actions, job_name)
 
             payload["unit"] = self.unit
             payload["experiment"] = whoami._get_latest_experiment_name()  # techdebt

--- a/pioreactor/background_jobs/monitor.py
+++ b/pioreactor/background_jobs/monitor.py
@@ -509,7 +509,6 @@ class Monitor(BackgroundJob):
             ).start()
 
         elif job_name in vars(pumping_actions):
-
             pump_action = getattr(pumping_actions, job_name)
 
             payload["unit"] = self.unit

--- a/pioreactor/tests/test_mqtt_to_db_streaming.py
+++ b/pioreactor/tests/test_mqtt_to_db_streaming.py
@@ -123,9 +123,9 @@ def test_dosing_events_land_in_db() -> None:
     ]
 
     with m2db.MqttToDBStreamer(parsers, unit=unit, experiment=exp):
-        from pioreactor.actions.pump import add_media
+        from pioreactor.actions.pump import pumping_actions
 
-        add_media(
+        pumping_actions.add_media(
             unit,
             exp,
             ml=1,

--- a/pioreactor/tests/test_pumps.py
+++ b/pioreactor/tests/test_pumps.py
@@ -145,7 +145,9 @@ def test_pump_will_disconnect_via_mqtt() -> None:
             return self._return
 
     expected_ml = 20
-    t = ThreadWithReturnValue(target=pumping_actions.add_media, args=(unit, exp, expected_ml), daemon=True)
+    t = ThreadWithReturnValue(
+        target=pumping_actions.add_media, args=(unit, exp, expected_ml), daemon=True
+    )
     t.start()
 
     pause()
@@ -177,7 +179,10 @@ def test_continuously_running_pump_will_disconnect_via_mqtt() -> None:
             return self._return
 
     t = ThreadWithReturnValue(
-        target=pumping_actions.add_media, args=(unit, exp), kwargs={"continuously": True}, daemon=True
+        target=pumping_actions.add_media,
+        args=(unit, exp),
+        kwargs={"continuously": True},
+        daemon=True,
     )
     t.start()
 

--- a/pioreactor/types.py
+++ b/pioreactor/types.py
@@ -7,6 +7,7 @@ import typing as t
 mL = float
 Seconds = float
 
+
 class DosingProgram(t.Protocol):
     """
     Used in Dosing automations
@@ -24,10 +25,18 @@ class Pump(t.Protocol):
     Used to create/override a pump
     Should return a non-negative float representing (approx) how much liquid was moved, in ml.
     """
-    def __call__(self, ml: float, duration: float, continously: bool,  source_of_event: str, unit: str, experiment: str) -> mL:
+
+    def __call__(
+        self,
+        ml: float,
+        duration: float,
+        continously: bool,
+        source_of_event: str,
+        unit: str,
+        experiment: str,
+    ) -> mL:
         # don't forget to return a float!
         ...
-
 
 
 MQTTMessagePayload = t.Union[bytes, bytearray]
@@ -136,5 +145,3 @@ GpioPin = t.Literal[
     20,
     21,
 ]
-
-

--- a/pioreactor/types.py
+++ b/pioreactor/types.py
@@ -4,15 +4,30 @@ from __future__ import annotations
 
 import typing as t
 
+mL = float
+Seconds = float
 
 class DosingProgram(t.Protocol):
     """
+    Used in Dosing automations
     Should return a non-negative float representing (approx) how much liquid was moved, in ml.
     """
 
-    def __call__(self, unit: str, experiment: str, ml: float, source_of_event: str) -> float:
+    def __call__(self, unit: str, experiment: str, ml: float, source_of_event: str) -> mL:
         # don't forget to return a float!
         ...
+
+
+class Pump(t.Protocol):
+    """
+
+    Used to create/override a pump
+    Should return a non-negative float representing (approx) how much liquid was moved, in ml.
+    """
+    def __call__(self, ml: float, duration: float, continously: bool,  source_of_event: str, unit: str, experiment: str) -> mL:
+        # don't forget to return a float!
+        ...
+
 
 
 MQTTMessagePayload = t.Union[bytes, bytearray]
@@ -122,5 +137,4 @@ GpioPin = t.Literal[
     21,
 ]
 
-mL = float
-Seconds = float
+


### PR DESCRIPTION
demo this idea of namespaces, so it's easier to override. However, pump_calibration is still a problem (doesn't handle non PWM pumps), so this only provides _some_ improvement. I do like some of the renaming and use of partials, and monitor.py looks better.