### PR TITLE
[wip] Better long running jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 #### Bug fixes
  - fix for OD calibration graph showing "two lines" in the terminal display
  - fix for updating over the internet when a Pioreactor is on a `A.devX` or `B.rcY` release
- - updating the UI software won't stop running activities
+ - updating the UI software won't prematurely stop any currently running activities
 
 ### 24.10.1
 

--- a/pioreactor/background_jobs/base.py
+++ b/pioreactor/background_jobs/base.py
@@ -246,7 +246,8 @@ class _BackgroundJob(metaclass=PostInitCaller):
     # initial state is disconnected
     state: pt.JobState = DISCONNECTED
     job_name: str = "background_job"
-    _clean: bool = False
+    _is_cleaned_up: bool = False  # mqtt connections closed, logger closed, etc.
+    _IS_LONG_RUNNING = False  # by default, jobs aren't long running (persistent over experiments)
 
     # published_settings is typically overwritten in the subclasses. Attributes here will
     # be published to MQTT and available settable attributes will be editable. Currently supported
@@ -331,20 +332,26 @@ class _BackgroundJob(metaclass=PostInitCaller):
 
         Typical sequence (doesn't represent calling stack, but "blocks of code" run)
 
-        C == calling class (usually a subclass)
-        P = BackgroundJob (this class)
+        P == BackgroundJob (this class)
+        C == calling class (a subclass)
 
-        P.__init__() # check for duplicate job
-        C.__init__() # risk of job failing here
+        P.__init__() # check for duplicate job, among other checks
+        C.__init__() # Note: risk of job failing here
         P.__post__init__()  # THIS FUNCTION
-        P.on_init_to_ready()  # default noop - can be overwritten in sub.
+        P.on_init_to_ready()  # default noop - can be overwritten in sub class C
         P.ready()
-        C.on_ready()
+        C.on_ready() # default noop
         """
 
         with JobManager() as jm:
             self._jm_key = jm.register_and_set_running(
-                self.unit, self.experiment, self.job_name, self._job_source, getpid(), leader_hostname
+                self.unit,
+                self.experiment,
+                self.job_name,
+                self._job_source,
+                getpid(),
+                leader_hostname,
+                self._IS_LONG_RUNNING,
             )
 
         # setting READY should happen after we write to the job manager, since a job might do a long-running
@@ -679,7 +686,7 @@ class _BackgroundJob(metaclass=PostInitCaller):
     def _set_up_exit_protocol(self) -> None:
         # here, we set up how jobs should disconnect and exit.
         def exit_gracefully(reason: int | str, *args) -> None:
-            if self._clean:
+            if self._is_cleaned_up:
                 return
 
             if isinstance(reason, int):
@@ -827,7 +834,7 @@ class _BackgroundJob(metaclass=PostInitCaller):
         self._disconnect_from_mqtt_clients()
         self._disconnect_from_loggers()
 
-        self._clean = True
+        self._is_cleaned_up = True
 
     def _publish_properties_string_to_broker(
         self, published_settings: dict[str, pt.PublishableSetting]
@@ -991,11 +998,24 @@ class _BackgroundJob(metaclass=PostInitCaller):
 
 class LongRunningBackgroundJob(_BackgroundJob):
     """
-    This doesn't check for is_active, so should be used for jobs like monitor, etc.
+    This doesn't check for is_active and doesn't obey `pio kill --all-jobs` so should be used for jobs like monitor, etc.
     """
+
+    _IS_LONG_RUNNING = True
 
     def __init__(self, unit: str, experiment: str) -> None:
         super().__init__(unit, experiment, source="app")
+
+
+class LongRunningBackgroundJobContrib(_BackgroundJob):
+    """
+    Used for jobs like logs2x, etc.
+    """
+
+    _IS_LONG_RUNNING = True
+
+    def __init__(self, unit: str, experiment: str, plugin_name: str) -> None:
+        super().__init__(unit, experiment, source=plugin_name)
 
 
 class BackgroundJob(_BackgroundJob):

--- a/pioreactor/utils/__init__.py
+++ b/pioreactor/utils/__init__.py
@@ -209,7 +209,13 @@ class managed_lifecycle:
 
         with JobManager() as jm:
             self._jm_key = jm.register_and_set_running(
-                self.unit, self.experiment, self.name, self._job_source, getpid(), ""
+                self.unit,
+                self.experiment,
+                self.name,
+                self._job_source,
+                getpid(),
+                "",
+                False,  # TODO: why is leader string empty?
             )
 
         return self
@@ -535,7 +541,6 @@ class JobManager:
         "circulate_media",
         "circulate_alt_media",
     )
-    LONG_RUNNING_JOBS = ("monitor", "mqtt_to_db_streaming")
 
     def __init__(self) -> None:
         self.db_path = f"{tempfile.gettempdir()}/local_intermittent_pioreactor_metadata.sqlite"
@@ -555,16 +560,24 @@ class JobManager:
             is_running   INTEGER NOT NULL,
             leader       TEXT NOT NULL,
             pid          INTEGER NOT NULL,
-            ended_at     TEXT
+            is_long_running_job INTEGER NOT NULL,
+            ended_at     TEXT,
         );
         """
         self.cursor.execute(create_table_query)
         self.conn.commit()
 
     def register_and_set_running(
-        self, unit: str, experiment: str, name: str, job_source: str | None, pid: int, leader: str
+        self,
+        unit: str,
+        experiment: str,
+        name: str,
+        job_source: str | None,
+        pid: int,
+        leader: str,
+        is_long_running_job: bool,
     ) -> JobMetadataKey:
-        insert_query = "INSERT INTO pio_job_metadata (started_at, is_running, job_source, experiment, unit, name, leader, pid, ended_at) VALUES (STRFTIME('%Y-%m-%dT%H:%M:%f000Z', 'NOW'), 1, :job_source, :experiment, :unit, :name, :leader, :pid, NULL);"
+        insert_query = "INSERT INTO pio_job_metadata (started_at, is_running, job_source, experiment, unit, name, leader, pid, is_long_running_job, ended_at) VALUES (STRFTIME('%Y-%m-%dT%H:%M:%f000Z', 'NOW'), 1, :job_source, :experiment, :unit, :name, :leader, :pid, :is_long_running_job, NULL);"
         self.cursor.execute(
             insert_query,
             {
@@ -574,6 +587,7 @@ class JobManager:
                 "pid": pid,
                 "leader": leader,
                 "name": name,
+                "is_long_running_job": is_long_running_job,
             },
         )
         self.conn.commit()
@@ -610,7 +624,9 @@ class JobManager:
 
         else:
             # Construct the SELECT query
-            select_query = f"SELECT name, pid FROM pio_job_metadata WHERE is_running=1 AND name NOT IN {self.LONG_RUNNING_JOBS}"
+            select_query = (
+                "SELECT name, pid FROM pio_job_metadata WHERE is_running=1 AND is_long_running_job=0"
+            )
 
             # Execute the query and fetch the results
             self.cursor.execute(select_query)


### PR DESCRIPTION
This is a better way to handle long-running jobs so they are not killed early. This solves the `pio kill --all-jobs` killing long-running plugins. 

- [ ] update and write new tests
- [ ] test for `log2x` plugins