### PR TITLE
Introduce Unit type alias for unit names

### DIFF
--- a/pioreactor/actions/leader/experiment_profile.py
+++ b/pioreactor/actions/leader/experiment_profile.py
@@ -31,6 +31,7 @@ from pioreactor.utils.timing import current_utc_timestamp
 from pioreactor.whoami import get_assigned_experiment_name
 from pioreactor.whoami import get_unit_name
 from pioreactor.whoami import is_testing_env
+from pioreactor.types import Unit
 
 BoolExpression = str | bool
 Env = dict[str, Any]
@@ -134,7 +135,7 @@ def check_syntax_of_bool_expression(bool_expression: BoolExpression) -> bool:
     return check_syntax(bool_expression)
 
 
-def check_if_job_running(unit: str, job: str) -> bool:
+def check_if_job_running(unit: Unit, job: str) -> bool:
     if is_testing_env():
         return True
     try:
@@ -196,7 +197,7 @@ def get_simple_priority(action: struct.Action):
 
 
 def wrapped_execute_action(
-    unit: str,
+    unit: Unit,
     experiment: str,
     global_env: Env,
     job_name: str,
@@ -351,7 +352,7 @@ def common_wrapped_execute_action(
 
 
 def when(
-    unit: str,
+    unit: Unit,
     experiment: str,
     parent_job: long_running_managed_lifecycle,
     job_name: str,
@@ -429,7 +430,7 @@ def when(
 
 
 def repeat(
-    unit: str,
+    unit: Unit,
     experiment: str,
     parent_job: long_running_managed_lifecycle,
     job_name: str,
@@ -519,7 +520,7 @@ def repeat(
 
 
 def log(
-    unit: str,
+    unit: Unit,
     experiment: str,
     parent_job: long_running_managed_lifecycle,
     job_name: str,
@@ -563,7 +564,7 @@ def log(
 
 
 def start_job(
-    unit: str,
+    unit: Unit,
     experiment: str,
     parent_job: long_running_managed_lifecycle,
     job_name: str,
@@ -617,7 +618,7 @@ def start_job(
 
 
 def pause_job(
-    unit: str,
+    unit: Unit,
     experiment: str,
     parent_job: long_running_managed_lifecycle,
     job_name: str,
@@ -660,7 +661,7 @@ def pause_job(
 
 
 def resume_job(
-    unit: str,
+    unit: Unit,
     experiment: str,
     parent_job: long_running_managed_lifecycle,
     job_name: str,
@@ -704,7 +705,7 @@ def resume_job(
 
 
 def stop_job(
-    unit: str,
+    unit: Unit,
     experiment: str,
     parent_job: long_running_managed_lifecycle,
     job_name: str,
@@ -744,7 +745,7 @@ def stop_job(
 
 
 def update_job(
-    unit: str,
+    unit: Unit,
     experiment: str,
     parent_job: long_running_managed_lifecycle,
     job_name: str,

--- a/pioreactor/actions/led_intensity.py
+++ b/pioreactor/actions/led_intensity.py
@@ -18,6 +18,7 @@ from pioreactor.pubsub import create_client
 from pioreactor.pubsub import QOS
 from pioreactor.types import LedChannel
 from pioreactor.types import LedIntensityValue
+from pioreactor.types import Unit
 from pioreactor.utils import JobManager
 from pioreactor.utils import local_intermittent_storage
 from pioreactor.utils.timing import current_utc_datetime
@@ -99,7 +100,7 @@ def _update_current_state(
 
 def led_intensity(
     desired_state: LEDsToIntensityMapping,
-    unit: str | None = None,
+    unit: Unit | None = None,
     experiment: str | None = None,
     verbose: bool = True,
     source_of_event: str | None = None,
@@ -112,7 +113,7 @@ def led_intensity(
     ------------
     desired_state: dict
         what you want the desired LED state to be. Leave keys out if you do wish to update that channel.
-    unit: str
+    unit: Unit
     experiment: str
     verbose: bool
         if True, log the change, and send event to led_event table & mqtt. This is FALSE

--- a/pioreactor/actions/pump.py
+++ b/pioreactor/actions/pump.py
@@ -16,6 +16,7 @@ from msgspec.structs import replace
 from pioreactor import exc
 from pioreactor import structs
 from pioreactor import types as pt
+from pioreactor.types import Unit
 from pioreactor import utils
 from pioreactor.calibrations import load_active_calibration
 from pioreactor.config import config
@@ -58,7 +59,7 @@ _thread_pool = ThreadPoolExecutor(max_workers=3)
 class PWMPump:
     def __init__(
         self,
-        unit: str,
+        unit: Unit,
         experiment: str,
         pin: pt.GpioPin,
         calibration: structs.SimplePeristalticPumpCalibration,

--- a/pioreactor/actions/self_test.py
+++ b/pioreactor/actions/self_test.py
@@ -43,6 +43,7 @@ from pioreactor.pubsub import prune_retained_messages
 from pioreactor.types import LedChannel
 from pioreactor.types import PdAngle
 from pioreactor.types import PdChannel
+from pioreactor.types import Unit
 from pioreactor.utils import is_pio_job_running
 from pioreactor.utils import local_persistent_storage
 from pioreactor.utils import managed_lifecycle
@@ -58,11 +59,11 @@ from pioreactor.whoami import get_unit_name
 from pioreactor.whoami import is_testing_env
 
 
-def test_pioreactor_HAT_present(managed_state, logger: CustomLogger, unit: str, experiment: str) -> None:
+def test_pioreactor_HAT_present(managed_state, logger: CustomLogger, unit: Unit, experiment: str) -> None:
     assert is_HAT_present(), "HAT is not connected"
 
 
-def test_REF_is_in_correct_position(managed_state, logger: CustomLogger, unit: str, experiment: str) -> None:
+def test_REF_is_in_correct_position(managed_state, logger: CustomLogger, unit: Unit, experiment: str) -> None:
     # this _also_ uses stirring to increase the variance in the non-REF.
     # The idea is to trigger stirring on and off and the REF should not see a change in signal / variance, but the other PD should.
 
@@ -115,7 +116,7 @@ def test_REF_is_in_correct_position(managed_state, logger: CustomLogger, unit: s
 
 
 def test_all_positive_correlations_between_pds_and_leds(
-    managed_state, logger: CustomLogger, unit: str, experiment: str
+    managed_state, logger: CustomLogger, unit: Unit, experiment: str
 ) -> None:
     """
     This tests that there is a positive correlation between the IR LED channel, and the photodiodes
@@ -252,7 +253,7 @@ def test_all_positive_correlations_between_pds_and_leds(
         ), f"missing {ir_led_channel} ⇝ {ir_pd_channel}, correlation: {results[(ir_led_channel, ir_pd_channel)]:0.2f}"
 
 
-def test_ambient_light_interference(managed_state, logger: CustomLogger, unit: str, experiment: str) -> None:
+def test_ambient_light_interference(managed_state, logger: CustomLogger, unit: Unit, experiment: str) -> None:
     # test ambient light IR interference. With all LEDs off, and the Pioreactor not in a sunny room, we should see near 0 light.
     assert is_HAT_present(), "HAT is not detected."
     adc_reader = ADCReader(
@@ -282,7 +283,7 @@ def test_ambient_light_interference(managed_state, logger: CustomLogger, unit: s
 
 
 def test_REF_is_lower_than_0_dot_256_volts(
-    managed_state, logger: CustomLogger, unit: str, experiment: str
+    managed_state, logger: CustomLogger, unit: Unit, experiment: str
 ) -> None:
     assert is_HAT_present(), "HAT is not detected."
 
@@ -332,7 +333,7 @@ def test_REF_is_lower_than_0_dot_256_volts(
 
 
 def test_PD_is_near_0_volts_for_blank(
-    managed_state, logger: CustomLogger, unit: str, experiment: str
+    managed_state, logger: CustomLogger, unit: Unit, experiment: str
 ) -> None:
     assert is_HAT_present(), "HAT is not detected."
     reference_channel = cast(PdChannel, config.get("od_config.photodiode_channel_reverse", REF_keyword))
@@ -369,11 +370,11 @@ def test_PD_is_near_0_volts_for_blank(
     assert mean_signal <= THRESHOLD, f"Blank signal too high: {mean_signal=} > {THRESHOLD}"
 
 
-def test_detect_heating_pcb(managed_state, logger: CustomLogger, unit: str, experiment: str) -> None:
+def test_detect_heating_pcb(managed_state, logger: CustomLogger, unit: Unit, experiment: str) -> None:
     assert is_heating_pcb_present(), "Heater PCB is not connected, or i2c is not working."
 
 
-def test_run_stirring_calibration(managed_state, logger: CustomLogger, unit: str, experiment: str) -> None:
+def test_run_stirring_calibration(managed_state, logger: CustomLogger, unit: Unit, experiment: str) -> None:
     from pioreactor.calibrations.stirring_calibration import run_stirring_calibration
 
     cal = run_stirring_calibration()
@@ -383,7 +384,7 @@ def test_run_stirring_calibration(managed_state, logger: CustomLogger, unit: str
 
 
 def test_positive_correlation_between_temperature_and_heating(
-    managed_state, logger: CustomLogger, unit: str, experiment: str
+    managed_state, logger: CustomLogger, unit: Unit, experiment: str
 ) -> None:
     assert is_heating_pcb_present(), "Heater PCB is not connected, or i2c is not working."
 
@@ -405,13 +406,13 @@ def test_positive_correlation_between_temperature_and_heating(
         ), f"Temp and DC% correlation was not high enough {dcs=}, {measured_pcb_temps=}"
 
 
-def test_aux_power_is_not_too_high(client: Client, logger: CustomLogger, unit: str, experiment: str) -> None:
+def test_aux_power_is_not_too_high(client: Client, logger: CustomLogger, unit: Unit, experiment: str) -> None:
     assert is_HAT_present(), "HAT was not detected."
     assert voltage_in_aux() <= 18.0, f"Voltage measured {voltage_in_aux()} > 18.0V"
 
 
 def test_positive_correlation_between_rpm_and_stirring(
-    client, logger: CustomLogger, unit: str, experiment: str
+    client, logger: CustomLogger, unit: Unit, experiment: str
 ) -> None:
     assert is_HAT_present(), "HAT was not detected."
     assert is_heating_pcb_present(), "Heating PCB was not detected."
@@ -464,7 +465,7 @@ class BatchTestRunner:
         self._thread.join()
         return SummableDict({"count_tested": self.count_tested, "count_passed": self.count_passed})
 
-    def _run(self, managed_state, logger: CustomLogger, unit: str, testing_experiment: str) -> None:
+    def _run(self, managed_state, logger: CustomLogger, unit: Unit, testing_experiment: str) -> None:
         for test in self.tests_to_run:
             test_name = test.__name__
 

--- a/pioreactor/automations/base.py
+++ b/pioreactor/automations/base.py
@@ -11,6 +11,7 @@ from msgspec.json import encode
 from pioreactor import exc
 from pioreactor import structs
 from pioreactor import types as pt
+from pioreactor.types import Unit
 from pioreactor.automations import events
 from pioreactor.background_jobs.base import BackgroundJob
 from pioreactor.pubsub import QOS
@@ -36,7 +37,7 @@ class AutomationJob(BackgroundJob):
     _latest_normalized_od: None | float = None
     _latest_od: None | dict[pt.PdChannel, float] = None
 
-    def __init__(self, unit: str, experiment: str) -> None:
+    def __init__(self, unit: Unit, experiment: str) -> None:
         super().__init__(unit, experiment)
         if self.automation_name in DISALLOWED_AUTOMATION_NAMES:
             raise NameError(f"{self.automation_name} is not allowed.")

--- a/pioreactor/background_jobs/base.py
+++ b/pioreactor/background_jobs/base.py
@@ -16,6 +16,7 @@ from msgspec.json import encode as dumps
 
 from pioreactor import structs
 from pioreactor import types as pt
+from pioreactor.types import Unit
 from pioreactor.config import config
 from pioreactor.config import leader_hostname
 from pioreactor.exc import NotActiveWorkerError
@@ -230,7 +231,7 @@ class _BackgroundJob(metaclass=PostInitCaller):
     source: str
         the source of where this job lives. "app" if main code base, <plugin name> if from a plugin, etc. This is used in logging.
     experiment: str
-    unit: str
+    unit: Unit
     """
 
     # Homie lifecycle (normally per device (i.e. an rpi) but we are using it for "nodes", in Homie parlance)
@@ -269,7 +270,7 @@ class _BackgroundJob(metaclass=PostInitCaller):
 
         cls.__init__ = wrapped_init
 
-    def __init__(self, unit: str, experiment: str, source: str = "app") -> None:
+    def __init__(self, unit: Unit, experiment: str, source: str = "app") -> None:
         if self.job_name in DISALLOWED_JOB_NAMES:
             raise ValueError("Job name not allowed.")
         if not self.job_name.islower():
@@ -962,7 +963,7 @@ class LongRunningBackgroundJob(_BackgroundJob):
 
     _IS_LONG_RUNNING = True
 
-    def __init__(self, unit: str, experiment: str) -> None:
+    def __init__(self, unit: Unit, experiment: str) -> None:
         super().__init__(unit, experiment, source="app")
 
 
@@ -973,7 +974,7 @@ class LongRunningBackgroundJobContrib(_BackgroundJob):
 
     _IS_LONG_RUNNING = True
 
-    def __init__(self, unit: str, experiment: str, plugin_name: str) -> None:
+    def __init__(self, unit: Unit, experiment: str, plugin_name: str) -> None:
         super().__init__(unit, experiment, source=plugin_name)
 
 
@@ -982,7 +983,7 @@ class BackgroundJob(_BackgroundJob):
     Worker jobs should inherit from this class.
     """
 
-    def __init__(self, unit: str, experiment: str) -> None:
+    def __init__(self, unit: Unit, experiment: str) -> None:
         if not is_active(unit):
             raise NotActiveWorkerError(
                 f"{unit} is not active. Make active in leader, or set ACTIVE=1 in the environment: ACTIVE=1 pio run ... "
@@ -1000,7 +1001,7 @@ class BackgroundJobContrib(_BackgroundJob):
         if cls.job_name == "background_job":
             raise NameError(f"must provide a job_name property to this BackgroundJob class {cls}.")
 
-    def __init__(self, unit: str, experiment: str, plugin_name: str) -> None:
+    def __init__(self, unit: Unit, experiment: str, plugin_name: str) -> None:
         super().__init__(unit, experiment, source=plugin_name)
 
 
@@ -1246,5 +1247,5 @@ class BackgroundJobWithDodgingContrib(BackgroundJobWithDodging):
         if cls.job_name == "background_job":
             raise NameError(f"must provide a job_name property to this BackgroundJob class {cls}.")
 
-    def __init__(self, unit: str, experiment: str, plugin_name: str) -> None:
+    def __init__(self, unit: Unit, experiment: str, plugin_name: str) -> None:
         super().__init__(unit=unit, experiment=experiment, source=plugin_name)

--- a/pioreactor/background_jobs/dosing_automation.py
+++ b/pioreactor/background_jobs/dosing_automation.py
@@ -14,6 +14,7 @@ from msgspec.json import decode
 from pioreactor import exc
 from pioreactor import structs
 from pioreactor import types as pt
+from pioreactor.types import Unit
 from pioreactor import whoami
 from pioreactor.actions.pump import add_alt_media
 from pioreactor.actions.pump import add_media
@@ -231,7 +232,7 @@ class DosingAutomationJob(AutomationJob):
 
     def __init__(
         self,
-        unit: str,
+        unit: Unit,
         experiment: str,
         duration: Optional[float] = None,
         skip_first_run: bool = False,

--- a/pioreactor/background_jobs/growth_rate_calculating.py
+++ b/pioreactor/background_jobs/growth_rate_calculating.py
@@ -49,6 +49,7 @@ from msgspec.json import decode
 
 from pioreactor import structs
 from pioreactor import types as pt
+from pioreactor.types import Unit
 from pioreactor import whoami
 from pioreactor.actions.od_blank import od_statistics
 from pioreactor.background_jobs.base import BackgroundJob
@@ -88,7 +89,7 @@ class GrowthRateCalculator(BackgroundJob):
 
     def __init__(
         self,
-        unit: str,
+        unit: Unit,
         experiment: str,
         ignore_cache: bool = False,
         source_obs_from_mqtt=True,

--- a/pioreactor/background_jobs/leader/mqtt_to_db_streaming.py
+++ b/pioreactor/background_jobs/leader/mqtt_to_db_streaming.py
@@ -14,6 +14,7 @@ from msgspec.json import decode as msgspec_loads
 
 from pioreactor import structs
 from pioreactor import types as pt
+from pioreactor.types import Unit
 from pioreactor.background_jobs.base import LongRunningBackgroundJob
 from pioreactor.config import config
 from pioreactor.hardware import PWM_TO_PIN
@@ -31,7 +32,7 @@ sqlite3.register_adapter(datetime.datetime, to_iso_format)
 
 
 class MetaData(Struct):
-    pioreactor_unit: str
+    pioreactor_unit: Unit
     experiment: str
     rest_of_topic: list[str]
 
@@ -64,7 +65,7 @@ class MqttToDBStreamer(LongRunningBackgroundJob):
 
     def __init__(
         self,
-        unit: str,
+        unit: Unit,
         experiment: str,
         topics_to_tables: list[TopicToParserToTable],
     ) -> None:

--- a/pioreactor/background_jobs/led_automation.py
+++ b/pioreactor/background_jobs/led_automation.py
@@ -18,6 +18,7 @@ from pioreactor.config import config
 from pioreactor.logging import create_logger
 from pioreactor.utils import whoami
 from pioreactor.utils.timing import current_utc_datetime
+from pioreactor.types import Unit
 from pioreactor.utils.timing import RepeatedTimer
 
 
@@ -52,7 +53,7 @@ class LEDAutomationJob(AutomationJob):
 
     def __init__(
         self,
-        unit: str,
+        unit: Unit,
         experiment: str,
         duration: float,
         skip_first_run: bool = False,

--- a/pioreactor/background_jobs/monitor.py
+++ b/pioreactor/background_jobs/monitor.py
@@ -30,6 +30,7 @@ from pioreactor.pubsub import get_from
 from pioreactor.pubsub import QOS
 from pioreactor.structs import Voltage
 from pioreactor.types import MQTTMessage
+from pioreactor.types import Unit
 from pioreactor.utils.networking import discover_workers_on_network
 from pioreactor.utils.networking import get_ip
 from pioreactor.utils.timing import current_utc_datetime
@@ -107,7 +108,7 @@ class Monitor(LongRunningBackgroundJob):
     _pre_button: list[Callable] = []
     _post_button: list[Callable] = []
 
-    def __init__(self, unit: str, experiment: str) -> None:
+    def __init__(self, unit: Unit, experiment: str) -> None:
         super().__init__(unit=unit, experiment=experiment)
 
         def pretty_version(info: tuple) -> str:

--- a/pioreactor/background_jobs/od_reading.py
+++ b/pioreactor/background_jobs/od_reading.py
@@ -61,6 +61,7 @@ from pioreactor import exc
 from pioreactor import hardware
 from pioreactor import structs
 from pioreactor import types as pt
+from pioreactor.types import Unit
 from pioreactor import whoami
 from pioreactor.background_jobs.base import BackgroundJob
 from pioreactor.background_jobs.base import LoggerMixin
@@ -794,7 +795,7 @@ class ODReader(BackgroundJob):
         channel_angle_map: dict[pt.PdChannel, pt.PdAngle],
         interval: Optional[float],
         adc_reader: ADCReader,
-        unit: str,
+        unit: Unit,
         experiment: str,
         ir_led_reference_tracker: Optional[IrLedReferenceTracker] = None,
         calibration_transformer: Optional[CalibrationTransformer] = None,
@@ -1228,7 +1229,7 @@ def start_od_reading(
     | None = cast(pt.PdAngleOrREF, config.get("od_config.photodiode_channel", "2", fallback=None)),
     interval: float | None = 1 / config.getfloat("od_reading.config", "samples_per_second", fallback=0.2),
     fake_data: bool = False,
-    unit: str | None = None,
+    unit: Unit | None = None,
     experiment: str | None = None,
     calibration: bool | structs.ODCalibration | None = True,
 ) -> ODReader:

--- a/pioreactor/background_jobs/stirring.py
+++ b/pioreactor/background_jobs/stirring.py
@@ -13,6 +13,7 @@ from typing import Optional
 import click
 
 import pioreactor.types as pt
+from pioreactor.types import Unit
 from pioreactor import error_codes
 from pioreactor import exc
 from pioreactor import hardware
@@ -206,7 +207,7 @@ class Stirrer(BackgroundJobWithDodging):
     def __init__(
         self,
         target_rpm: Optional[float],
-        unit: str,
+        unit: Unit,
         experiment: str,
         rpm_calculator: Optional[RpmCalculator] = None,
         calibration: bool | structs.SimpleStirringCalibration | None = True,

--- a/pioreactor/background_jobs/temperature_automation.py
+++ b/pioreactor/background_jobs/temperature_automation.py
@@ -14,6 +14,7 @@ from pioreactor import exc
 from pioreactor import hardware
 from pioreactor import structs
 from pioreactor import types as pt
+from pioreactor.types import Unit
 from pioreactor.automations.base import AutomationJob
 from pioreactor.config import config
 from pioreactor.logging import create_logger
@@ -94,7 +95,7 @@ class TemperatureAutomationJob(AutomationJob):
 
     def __init__(
         self,
-        unit: str,
+        unit: Unit,
         experiment: str,
         **kwargs,
     ) -> None:

--- a/pioreactor/calibrations/od_calibration_single_vial.py
+++ b/pioreactor/calibrations/od_calibration_single_vial.py
@@ -19,6 +19,7 @@ from msgspec.json import format
 
 from pioreactor import structs
 from pioreactor import types as pt
+from pioreactor.types import Unit
 from pioreactor.background_jobs.od_reading import start_od_reading
 from pioreactor.background_jobs.stirring import start_stirring as stirring
 from pioreactor.background_jobs.stirring import Stirrer
@@ -366,7 +367,7 @@ def to_struct(
     angle,
     name: str,
     pd_channel: pt.PdChannel,
-    unit: str,
+    unit: Unit,
 ) -> structs.OD600Calibration:
     data_blob = structs.OD600Calibration(
         created_at=current_utc_datetime(),

--- a/pioreactor/calibrations/od_calibration_using_standards.py
+++ b/pioreactor/calibrations/od_calibration_using_standards.py
@@ -25,6 +25,7 @@ from msgspec.json import format
 
 from pioreactor import structs
 from pioreactor import types as pt
+from pioreactor.types import Unit
 from pioreactor.background_jobs.od_reading import start_od_reading
 from pioreactor.background_jobs.stirring import start_stirring as stirring
 from pioreactor.background_jobs.stirring import Stirrer
@@ -158,7 +159,7 @@ def to_struct(
     angle,
     name: str,
     pd_channel: pt.PdChannel,
-    unit: str,
+    unit: Unit,
 ) -> structs.OD600Calibration:
     data_blob = structs.OD600Calibration(
         created_at=current_utc_datetime(),

--- a/pioreactor/calibrations/pump_calibration.py
+++ b/pioreactor/calibrations/pump_calibration.py
@@ -25,6 +25,7 @@ from pioreactor.config import config
 from pioreactor.hardware import voltage_in_aux
 from pioreactor.logging import create_logger
 from pioreactor.types import PumpCalibrationDevices
+from pioreactor.types import Unit
 from pioreactor.utils import managed_lifecycle
 from pioreactor.utils.math_helpers import correlation
 from pioreactor.utils.math_helpers import simple_linear_regression_with_forced_nil_intercept
@@ -106,7 +107,7 @@ def get_metadata_from_user(pump_device: PumpCalibrationDevices) -> str:
 
 
 def setup(
-    pump_device: PumpCalibrationDevices, execute_pump: Callable, hz: float, dc: float, unit: str
+    pump_device: PumpCalibrationDevices, execute_pump: Callable, hz: float, dc: float, unit: Unit
 ) -> None:
     # set up...
     channel_pump_is_configured_for = config.get("PWM_reverse", pump_device.removesuffix("_pump"))
@@ -210,7 +211,7 @@ def plot_data(x, y, title, x_min=None, x_max=None, interpolation_curve=None, hig
 
 
 def run_tests(
-    execute_pump: Callable, hz: float, dc: float, unit: str, mls_to_calibrate_for: list[float]
+    execute_pump: Callable, hz: float, dc: float, unit: Unit, mls_to_calibrate_for: list[float]
 ) -> tuple[list[float], list[float], float, float]:
     clear()
     echo()
@@ -342,7 +343,7 @@ def save_results(
     voltage: float,
     durations: list[float],
     volumes: list[float],
-    unit: str,
+    unit: Unit,
 ) -> structs.SimplePeristalticPumpCalibration:
     pump_calibration_result = structs.SimplePeristalticPumpCalibration(
         calibration_name=name,

--- a/pioreactor/cli/pios.py
+++ b/pioreactor/cli/pios.py
@@ -21,6 +21,7 @@ from pioreactor.exc import SSHError
 from pioreactor.logging import create_logger
 from pioreactor.mureq import HTTPException
 from pioreactor.pubsub import post_into
+from pioreactor.types import Unit
 from pioreactor.utils import ClusterJobManager
 from pioreactor.utils.networking import cp_file_across_cluster
 from pioreactor.utils.networking import resolve_to_address
@@ -158,7 +159,7 @@ if am_I_leader() or is_testing_env():
         conn.commit()
         conn.close()
 
-    def sync_config_files(unit: str, shared: bool, specific: bool) -> None:
+    def sync_config_files(unit: Unit, shared: bool, specific: bool) -> None:
         """
         Moves
 
@@ -208,7 +209,7 @@ if am_I_leader() or is_testing_env():
 
         logger = create_logger("cp", unit=get_unit_name(), experiment=UNIVERSAL_EXPERIMENT)
 
-        def _thread_function(unit: str) -> bool:
+        def _thread_function(unit: Unit) -> bool:
             logger.debug(f"Copying {filepath} to {unit}:{filepath}...")
             try:
                 cp_file_across_cluster(unit, filepath, filepath, timeout=30)
@@ -242,7 +243,7 @@ if am_I_leader() or is_testing_env():
 
         logger = create_logger("rm", unit=get_unit_name(), experiment=UNIVERSAL_EXPERIMENT)
 
-        def _thread_function(unit: str) -> bool:
+        def _thread_function(unit: Unit) -> bool:
             try:
                 logger.debug(f"deleting {unit}:{filepath}...")
                 r = post_into(
@@ -295,7 +296,7 @@ if am_I_leader() or is_testing_env():
                 options["source"] = source
                 args = f"--source {source}"
 
-            def _thread_function(unit: str) -> tuple[bool, dict]:
+            def _thread_function(unit: Unit) -> tuple[bool, dict]:
                 try:
                     r = post_into(
                         resolve_to_address(unit), "/unit_api/system/update", json={"options": options}
@@ -375,7 +376,7 @@ if am_I_leader() or is_testing_env():
         if repo is not None:
             options["repo"] = repo
 
-        def _thread_function(unit: str) -> tuple[bool, dict]:
+        def _thread_function(unit: Unit) -> tuple[bool, dict]:
             try:
                 r = post_into(
                     resolve_to_address(unit), "/unit_api/system/update/app", json={"options": options}
@@ -452,7 +453,7 @@ if am_I_leader() or is_testing_env():
         if repo is not None:
             options["repo"] = repo
 
-        def _thread_function(unit: str) -> tuple[bool, dict]:
+        def _thread_function(unit: Unit) -> tuple[bool, dict]:
             try:
                 r = post_into(
                     resolve_to_address(unit), "/unit_api/system/update/ui", json={"options": options}
@@ -511,7 +512,7 @@ if am_I_leader() or is_testing_env():
         if source:
             commands["options"] = {"source": source}
 
-        def _thread_function(unit: str) -> tuple[bool, dict]:
+        def _thread_function(unit: Unit) -> tuple[bool, dict]:
             try:
                 r = post_into(
                     resolve_to_address(unit), "/unit_api/plugins/install", json=commands, timeout=60
@@ -553,7 +554,7 @@ if am_I_leader() or is_testing_env():
         logger = create_logger("uninstall_plugin", unit=get_unit_name(), experiment=UNIVERSAL_EXPERIMENT)
         commands = {"args": [plugin]}
 
-        def _thread_function(unit: str) -> tuple[bool, dict]:
+        def _thread_function(unit: Unit) -> tuple[bool, dict]:
             try:
                 r = post_into(
                     resolve_to_address(unit), "/unit_api/plugins/uninstall", json=commands, timeout=60
@@ -609,7 +610,7 @@ if am_I_leader() or is_testing_env():
 
         logger = create_logger("sync_configs", unit=get_unit_name(), experiment=UNIVERSAL_EXPERIMENT)
 
-        def _thread_function(unit: str) -> bool:
+        def _thread_function(unit: Unit) -> bool:
             logger.debug(f"Syncing configs on {unit}...")
             try:
                 sync_config_files(unit, shared, specific)
@@ -728,7 +729,7 @@ if am_I_leader() or is_testing_env():
 
         data = parse_click_arguments(extra_args)
 
-        def _thread_function(unit: str) -> tuple[bool, dict]:
+        def _thread_function(unit: Unit) -> tuple[bool, dict]:
             try:
                 r = post_into(resolve_to_address(unit), f"/unit_api/jobs/run/job_name/{job}", json=data)
                 r.raise_for_status()
@@ -768,7 +769,7 @@ if am_I_leader() or is_testing_env():
             if confirm != "Y":
                 sys.exit(1)
 
-        def _thread_function(unit: str) -> bool:
+        def _thread_function(unit: Unit) -> bool:
             try:
                 post_into(resolve_to_address(unit), "/unit_api/system/shutdown", timeout=60)
                 return True
@@ -801,7 +802,7 @@ if am_I_leader() or is_testing_env():
             if confirm != "Y":
                 sys.exit(1)
 
-        def _thread_function(unit: str) -> bool:
+        def _thread_function(unit: Unit) -> bool:
             try:
                 post_into(resolve_to_address(unit), "/unit_api/system/reboot", timeout=60)
                 return True

--- a/pioreactor/experiment_profiles/profile_struct.py
+++ b/pioreactor/experiment_profiles/profile_struct.py
@@ -5,6 +5,7 @@ import typing as t
 
 from msgspec import field
 from msgspec import Struct
+from pioreactor.types import Unit
 
 
 bool_expression = str | bool
@@ -99,7 +100,7 @@ class Job(Struct, forbid_unknown_fields=True):
     # logging?
 
 
-PioreactorUnitName = str
+PioreactorUnitName = Unit
 PioreactorLabel = str
 JobName = str
 Jobs = dict[JobName, Job]

--- a/pioreactor/logging.py
+++ b/pioreactor/logging.py
@@ -13,6 +13,7 @@ from pioreactor.exc import NotAssignedAnExperimentError
 from pioreactor.whoami import get_assigned_experiment_name
 from pioreactor.whoami import get_unit_name
 from pioreactor.whoami import UNIVERSAL_EXPERIMENT
+from pioreactor.types import Unit
 
 if TYPE_CHECKING:
     from pioreactor.pubsub import Client
@@ -141,7 +142,7 @@ class MQTTHandler(logging.Handler):
 
 def create_logger(
     name: str,
-    unit: str | None = None,
+    unit: Unit | None = None,
     experiment: str | None = None,
     source: str = "app",
     to_mqtt: bool = True,

--- a/pioreactor/pubsub.py
+++ b/pioreactor/pubsub.py
@@ -20,6 +20,7 @@ from pioreactor.config import config
 from pioreactor.config import leader_address
 from pioreactor.config import mqtt_address
 from pioreactor.types import MQTTMessage
+from pioreactor.types import Unit
 
 
 def add_hash_suffix(s: str) -> str:
@@ -330,7 +331,7 @@ class collect_all_logs_of_level:
     # We can use this to check that the logs are actually being published as we expect
     # We can also use this to check that the log levels are being set as we expect
 
-    def __init__(self, log_level: str, unit: str, experiment: str) -> None:
+    def __init__(self, log_level: str, unit: Unit, experiment: str) -> None:
         # set the log level we are looking for
         self.log_level = log_level.upper()
         # set the unit and experiment we are looking for

--- a/pioreactor/structs.py
+++ b/pioreactor/structs.py
@@ -16,6 +16,7 @@ from msgspec.yaml import encode as yaml_encode
 
 from pioreactor import exc
 from pioreactor import types as pt
+from pioreactor.types import Unit
 from pioreactor.logging import create_logger
 
 
@@ -50,7 +51,7 @@ class AutomationSettings(JSONPrintedStruct):
     Metadata produced when settings in an automation job change
     """
 
-    pioreactor_unit: str
+    pioreactor_unit: Unit
     experiment: str
     started_at: t.Annotated[datetime, Meta(tz=True)]
     ended_at: t.Optional[t.Annotated[datetime, Meta(tz=True)]]
@@ -164,7 +165,7 @@ Y = float
 
 class CalibrationBase(Struct, tag_field="calibration_type", kw_only=True):
     calibration_name: str
-    calibrated_on_pioreactor_unit: str
+    calibrated_on_pioreactor_unit: Unit
     created_at: t.Annotated[datetime, Meta(tz=True)]
     curve_data_: list[float]
     curve_type: str  # ex: "poly"

--- a/pioreactor/tests/test_background_job.py
+++ b/pioreactor/tests/test_background_job.py
@@ -17,6 +17,7 @@ from pioreactor.pubsub import publish
 from pioreactor.pubsub import subscribe
 from pioreactor.pubsub import subscribe_and_callback
 from pioreactor.types import MQTTMessage
+from pioreactor.types import Unit
 from pioreactor.utils import is_pio_job_running
 from pioreactor.whoami import get_unit_name
 
@@ -135,7 +136,7 @@ def test_what_happens_when_an_error_occurs_in_init_but_we_catch_and_disconnect()
     class TestJob(BackgroundJob):
         job_name = "testjob"
 
-        def __init__(self, unit: str, experiment: str) -> None:
+        def __init__(self, unit: Unit, experiment: str) -> None:
             super(TestJob, self).__init__(unit=unit, experiment=experiment)
             try:
                 raise ZeroDivisionError()
@@ -166,7 +167,7 @@ def test_what_happens_when_an_error_occurs_in_init_but_we_dont_catch() -> None:
     class TestJob(BackgroundJob):
         job_name = "testjob"
 
-        def __init__(self, unit: str, experiment: str) -> None:
+        def __init__(self, unit: Unit, experiment: str) -> None:
             super(TestJob, self).__init__(unit=unit, experiment=experiment)
             raise ZeroDivisionError()
 
@@ -198,7 +199,7 @@ def test_state_transition_callbacks() -> None:
         called_on_sleeping_to_ready = False
         called_on_init_to_ready = False
 
-        def __init__(self, unit: str, experiment: str) -> None:
+        def __init__(self, unit: Unit, experiment: str) -> None:
             super(TestJob, self).__init__(unit=unit, experiment=experiment)
 
         def on_init(self) -> None:
@@ -586,11 +587,11 @@ def test_subclasses_provide_a_unique_job_name_for_contrib():
     with pytest.raises(NameError):
 
         class TestJobBad(BackgroundJobContrib):
-            def __init__(self, unit: str, experiment: str) -> None:
+            def __init__(self, unit: Unit, experiment: str) -> None:
                 super(TestJobBad, self).__init__(unit=unit, experiment=experiment, plugin_name="test")
 
     class TestJobOkay(BackgroundJobContrib):
         job_name = "test_job"
 
-        def __init__(self, unit: str, experiment: str) -> None:
+        def __init__(self, unit: Unit, experiment: str) -> None:
             super(TestJobOkay, self).__init__(unit=unit, experiment=experiment, plugin_name="test")

--- a/pioreactor/tests/utils.py
+++ b/pioreactor/tests/utils.py
@@ -13,6 +13,7 @@ from pioreactor.structs import DosingEvent
 from pioreactor.structs import ODReadings
 from pioreactor.structs import RawODReading
 from pioreactor.utils.timing import to_datetime
+from pioreactor.types import Unit
 
 T = TypeVar("T")
 
@@ -67,7 +68,7 @@ class StreamODReadingsFromExport:
         self,
         filename: str,
         skip_first_n_rows: int = 0,
-        pioreactor_unit: str = "$broadcast",
+        pioreactor_unit: Unit = "$broadcast",
         experiment="$experiment",
     ):
         self.filename = filename
@@ -106,7 +107,7 @@ class StreamDosingEventsFromExport:
         self,
         filename: str,
         skip_first_n_rows: int = 0,
-        pioreactor_unit: str = "$broadcast",
+        pioreactor_unit: Unit = "$broadcast",
         experiment="$experiment",
     ):
         self.filename = filename

--- a/pioreactor/types.py
+++ b/pioreactor/types.py
@@ -6,6 +6,8 @@ import typing as t
 
 from msgspec import Meta
 
+Unit = str
+
 if t.TYPE_CHECKING:
     from pioreactor.pubsub import Client
     from pioreactor.logging import CustomLogger
@@ -18,7 +20,7 @@ class DosingProgram(t.Protocol):
 
     def __call__(
         self,
-        unit: str,
+        unit: Unit,
         experiment: str,
         ml: float,
         source_of_event: str,

--- a/pioreactor/utils/__init__.py
+++ b/pioreactor/utils/__init__.py
@@ -20,6 +20,8 @@ from typing import Self
 from typing import Sequence
 from typing import TYPE_CHECKING
 
+from pioreactor.types import Unit
+
 from msgspec import DecodeError
 from msgspec import Struct
 from msgspec.json import decode as loads
@@ -147,7 +149,7 @@ class managed_lifecycle:
 
     def __init__(
         self,
-        unit: str,
+        unit: Unit,
         experiment: str,
         name: str,
         mqtt_client: Client | None = None,
@@ -282,7 +284,7 @@ class managed_lifecycle:
 class long_running_managed_lifecycle(managed_lifecycle):
     def __init__(
         self,
-        unit: str,
+        unit: Unit,
         experiment: str,
         name: str,
         mqtt_client: Client | None = None,
@@ -677,7 +679,7 @@ class JobManager:
 
     def register_and_set_running(
         self,
-        unit: str,
+        unit: Unit,
         experiment: str,
         job_name: str,
         job_source: str | None,
@@ -887,7 +889,7 @@ class ClusterJobManager:
             if job_id:
                 params["job_id"] = job_id
 
-        def _thread_function(unit: str) -> tuple[bool, dict]:
+        def _thread_function(unit: Unit) -> tuple[bool, dict]:
             try:
                 r = patch_into(resolve_to_address(unit), endpoint, params=params)
                 r.raise_for_status()

--- a/pioreactor/utils/networking.py
+++ b/pioreactor/utils/networking.py
@@ -11,6 +11,7 @@ from typing import Generator
 from pioreactor.config import config
 from pioreactor.exc import RsyncError
 from pioreactor.exc import SSHError
+from pioreactor.types import Unit
 
 
 def ssh(address: str, command: str):
@@ -40,7 +41,7 @@ def rsync(*args: str) -> None:
 
 
 def cp_file_across_cluster(
-    unit: str, localpath: str, remotepath: str, timeout: int = 5, user="pioreactor"
+    unit: Unit, localpath: str, remotepath: str, timeout: int = 5, user="pioreactor"
 ) -> None:
     try:
         rsync(

--- a/pioreactor/whoami.py
+++ b/pioreactor/whoami.py
@@ -11,6 +11,7 @@ from pioreactor import mureq
 from pioreactor.exc import NotAssignedAnExperimentError
 from pioreactor.exc import NoWorkerFoundError
 from pioreactor.version import version_text_to_tuple
+from pioreactor.types import Unit
 
 
 UNIVERSAL_IDENTIFIER = "$broadcast"
@@ -31,11 +32,11 @@ def get_testing_experiment_name() -> str:
         return f"_testing_{NO_EXPERIMENT}"
 
 
-def get_assigned_experiment_name(unit_name: str) -> str:
+def get_assigned_experiment_name(unit_name: Unit) -> str:
     return _get_assigned_experiment_name(unit_name)
 
 
-def _get_assigned_experiment_name(unit_name: str) -> str:
+def _get_assigned_experiment_name(unit_name: Unit) -> str:
     from pioreactor.pubsub import get_from_leader
     from pioreactor.config import leader_address
 
@@ -75,7 +76,7 @@ def _get_assigned_experiment_name(unit_name: str) -> str:
         )
 
 
-def is_active(unit_name: str) -> bool:
+def is_active(unit_name: Unit) -> bool:
     if os.environ.get("ACTIVE") == "1" or is_testing_env():
         return True
     elif os.environ.get("ACTIVE") == "0":
@@ -115,7 +116,7 @@ def get_hostname() -> str:
 
 
 @cache
-def get_unit_name() -> str:
+def get_unit_name() -> Unit:
     hostname = get_hostname()
 
     if hostname == "raspberrypi":


### PR DESCRIPTION
## Summary
- add `Unit` alias to represent a pioreactor unit
- annotate `get_unit_name` and related helpers with `Unit`
- use `Unit` throughout the codebase

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'msgspec')*

------
https://chatgpt.com/codex/tasks/task_e_685227ce0cc88322a766f5a03a123a9b