### PR TITLE
Introduce Unit and Experiment type aliases

### DIFF
--- a/pioreactor/actions/od_blank.py
+++ b/pioreactor/actions/od_blank.py
@@ -97,7 +97,7 @@ def od_statistics(
         return means, variances
 
 
-def delete_od_blank(unit: str | None = None, experiment: str | None = None):
+def delete_od_blank(unit: pt.Unit | None = None, experiment: pt.Experiment | None = None):
     action_name = "od_blank"
     unit = unit or whoami.get_unit_name()
     experiment = experiment or whoami.get_assigned_experiment_name(unit)
@@ -129,8 +129,8 @@ def od_blank(
     od_angle_channel1: pt.PdAngleOrREF,
     od_angle_channel2: pt.PdAngleOrREF,
     n_samples: int = 20,
-    unit: str | None = None,
-    experiment: str | None = None,
+    unit: pt.Unit | None = None,
+    experiment: pt.Experiment | None = None,
 ) -> dict[pt.PdChannel, pt.OD]:
     from pioreactor.background_jobs.od_reading import start_od_reading
 

--- a/pioreactor/automations/base.py
+++ b/pioreactor/automations/base.py
@@ -36,7 +36,7 @@ class AutomationJob(BackgroundJob):
     _latest_normalized_od: None | float = None
     _latest_od: None | dict[pt.PdChannel, float] = None
 
-    def __init__(self, unit: str, experiment: str) -> None:
+    def __init__(self, unit: pt.Unit, experiment: pt.Experiment) -> None:
         super().__init__(unit, experiment)
         if self.automation_name in DISALLOWED_AUTOMATION_NAMES:
             raise NameError(f"{self.automation_name} is not allowed.")

--- a/pioreactor/background_jobs/base.py
+++ b/pioreactor/background_jobs/base.py
@@ -271,7 +271,7 @@ class _BackgroundJob(metaclass=PostInitCaller):
 
         cls.__init__ = wrapped_init
 
-    def __init__(self, unit: str, experiment: str, source: str = "app") -> None:
+    def __init__(self, unit: pt.Unit, experiment: pt.Experiment, source: str = "app") -> None:
         if self.job_name in DISALLOWED_JOB_NAMES:
             raise ValueError("Job name not allowed.")
         if not self.job_name.islower():
@@ -976,7 +976,7 @@ class LongRunningBackgroundJob(_BackgroundJob):
 
     _IS_LONG_RUNNING = True
 
-    def __init__(self, unit: str, experiment: str) -> None:
+    def __init__(self, unit: pt.Unit, experiment: pt.Experiment) -> None:
         super().__init__(unit, experiment, source="app")
 
 
@@ -987,7 +987,7 @@ class LongRunningBackgroundJobContrib(_BackgroundJob):
 
     _IS_LONG_RUNNING = True
 
-    def __init__(self, unit: str, experiment: str, plugin_name: str) -> None:
+    def __init__(self, unit: pt.Unit, experiment: pt.Experiment, plugin_name: str) -> None:
         super().__init__(unit, experiment, source=plugin_name)
 
 
@@ -996,7 +996,7 @@ class BackgroundJob(_BackgroundJob):
     Worker jobs should inherit from this class.
     """
 
-    def __init__(self, unit: str, experiment: str) -> None:
+    def __init__(self, unit: pt.Unit, experiment: pt.Experiment) -> None:
         if not is_active(unit):
             raise NotActiveWorkerError(
                 f"{unit} is not active. Make active in leader, or set ACTIVE=1 in the environment: ACTIVE=1 pio run ... "
@@ -1014,7 +1014,7 @@ class BackgroundJobContrib(_BackgroundJob):
         if cls.job_name == "background_job":
             raise NameError(f"must provide a job_name property to this BackgroundJob class {cls}.")
 
-    def __init__(self, unit: str, experiment: str, plugin_name: str) -> None:
+    def __init__(self, unit: pt.Unit, experiment: pt.Experiment, plugin_name: str) -> None:
         super().__init__(unit, experiment, source=plugin_name)
 
 
@@ -1259,5 +1259,5 @@ class BackgroundJobWithDodgingContrib(BackgroundJobWithDodging):
         if cls.job_name == "background_job":
             raise NameError(f"must provide a job_name property to this BackgroundJob class {cls}.")
 
-    def __init__(self, unit: str, experiment: str, plugin_name: str) -> None:
+    def __init__(self, unit: pt.Unit, experiment: pt.Experiment, plugin_name: str) -> None:
         super().__init__(unit=unit, experiment=experiment, source=plugin_name)

--- a/pioreactor/background_jobs/leader/mqtt_to_db_streaming.py
+++ b/pioreactor/background_jobs/leader/mqtt_to_db_streaming.py
@@ -31,8 +31,8 @@ sqlite3.register_adapter(datetime.datetime, to_iso_format)
 
 
 class MetaData(Struct):
-    pioreactor_unit: str
-    experiment: str
+    pioreactor_unit: pt.Unit
+    experiment: pt.Experiment
     rest_of_topic: list[str]
 
 
@@ -64,8 +64,8 @@ class MqttToDBStreamer(LongRunningBackgroundJob):
 
     def __init__(
         self,
-        unit: str,
-        experiment: str,
+        unit: pt.Unit,
+        experiment: pt.Experiment,
         topics_to_tables: list[TopicToParserToTable],
     ) -> None:
         super().__init__(unit, experiment)

--- a/pioreactor/background_jobs/led_automation.py
+++ b/pioreactor/background_jobs/led_automation.py
@@ -52,8 +52,8 @@ class LEDAutomationJob(AutomationJob):
 
     def __init__(
         self,
-        unit: str,
-        experiment: str,
+        unit: pt.Unit,
+        experiment: pt.Experiment,
         duration: float,
         skip_first_run: bool = False,
         **kwargs,

--- a/pioreactor/background_jobs/monitor.py
+++ b/pioreactor/background_jobs/monitor.py
@@ -15,6 +15,7 @@ from pioreactor import error_codes
 from pioreactor import utils
 from pioreactor import version
 from pioreactor import whoami
+from pioreactor import types as pt
 from pioreactor.background_jobs.base import LongRunningBackgroundJob
 from pioreactor.cluster_management import get_workers_in_inventory
 from pioreactor.config import config
@@ -107,7 +108,7 @@ class Monitor(LongRunningBackgroundJob):
     _pre_button: list[Callable] = []
     _post_button: list[Callable] = []
 
-    def __init__(self, unit: str, experiment: str) -> None:
+    def __init__(self, unit: pt.Unit, experiment: pt.Experiment) -> None:
         super().__init__(unit=unit, experiment=experiment)
 
         def pretty_version(info: tuple) -> str:

--- a/pioreactor/background_jobs/od_reading.py
+++ b/pioreactor/background_jobs/od_reading.py
@@ -795,8 +795,8 @@ class ODReader(BackgroundJob):
         channel_angle_map: dict[pt.PdChannel, pt.PdAngle],
         interval: Optional[float],
         adc_reader: ADCReader,
-        unit: str,
-        experiment: str,
+        unit: pt.Unit,
+        experiment: pt.Experiment,
         ir_led_reference_tracker: Optional[IrLedReferenceTracker] = None,
         calibration_transformer: Optional[CalibrationTransformer] = None,
     ) -> None:
@@ -1227,8 +1227,8 @@ def start_od_reading(
     od_angle_channel2: pt.PdAngleOrREF | None,
     interval: float | None = None,
     fake_data: bool = False,
-    unit: str | None = None,
-    experiment: str | None = None,
+    unit: pt.Unit | None = None,
+    experiment: pt.Experiment | None = None,
     calibration: bool | structs.ODCalibration | None = True,
 ) -> ODReader:
     """

--- a/pioreactor/background_jobs/stirring.py
+++ b/pioreactor/background_jobs/stirring.py
@@ -208,8 +208,8 @@ class Stirrer(BackgroundJobWithDodging):
     def __init__(
         self,
         target_rpm: Optional[float],
-        unit: str,
-        experiment: str,
+        unit: pt.Unit,
+        experiment: pt.Experiment,
         rpm_calculator: Optional[RpmCalculator] = None,
         calibration: bool | structs.SimpleStirringCalibration | None = True,
         enable_dodging_od: bool = False,
@@ -593,8 +593,8 @@ class Stirrer(BackgroundJobWithDodging):
 
 def start_stirring(
     target_rpm: float | None = 500,
-    unit: str | None = None,
-    experiment: str | None = None,
+    unit: pt.Unit | None = None,
+    experiment: pt.Experiment | None = None,
     use_rpm: bool = True,
     calibration: bool | structs.SimpleStirringCalibration | None = True,
     enable_dodging_od: bool = False,

--- a/pioreactor/background_jobs/temperature_automation.py
+++ b/pioreactor/background_jobs/temperature_automation.py
@@ -94,8 +94,8 @@ class TemperatureAutomationJob(AutomationJob):
 
     def __init__(
         self,
-        unit: str,
-        experiment: str,
+        unit: pt.Unit,
+        experiment: pt.Experiment,
         **kwargs,
     ) -> None:
         super(TemperatureAutomationJob, self).__init__(unit, experiment)

--- a/pioreactor/logging.py
+++ b/pioreactor/logging.py
@@ -13,6 +13,7 @@ from pioreactor.exc import NotAssignedAnExperimentError
 from pioreactor.whoami import get_assigned_experiment_name
 from pioreactor.whoami import get_unit_name
 from pioreactor.whoami import UNIVERSAL_EXPERIMENT
+from pioreactor import types as pt
 
 if TYPE_CHECKING:
     from pioreactor.pubsub import Client
@@ -141,8 +142,8 @@ class MQTTHandler(logging.Handler):
 
 def create_logger(
     name: str,
-    unit: str | None = None,
-    experiment: str | None = None,
+    unit: pt.Unit | None = None,
+    experiment: pt.Experiment | None = None,
     source: str = "app",
     to_mqtt: bool = True,
     pub_client: Client | None = None,

--- a/pioreactor/pubsub.py
+++ b/pioreactor/pubsub.py
@@ -10,6 +10,8 @@ from typing import Any
 from typing import Callable
 from typing import Optional
 
+from pioreactor import types as pt
+
 from msgspec import Struct
 from msgspec.json import decode as loads
 from paho.mqtt.client import Client as PahoClient
@@ -330,7 +332,7 @@ class collect_all_logs_of_level:
     # We can use this to check that the logs are actually being published as we expect
     # We can also use this to check that the log levels are being set as we expect
 
-    def __init__(self, log_level: str, unit: str, experiment: str) -> None:
+    def __init__(self, log_level: str, unit: pt.Unit, experiment: pt.Experiment) -> None:
         # set the log level we are looking for
         self.log_level = log_level.upper()
         # set the unit and experiment we are looking for

--- a/pioreactor/structs.py
+++ b/pioreactor/structs.py
@@ -50,8 +50,8 @@ class AutomationSettings(JSONPrintedStruct):
     Metadata produced when settings in an automation job change
     """
 
-    pioreactor_unit: str
-    experiment: str
+    pioreactor_unit: pt.Unit
+    experiment: pt.Experiment
     started_at: t.Annotated[datetime, Meta(tz=True)]
     ended_at: t.Optional[t.Annotated[datetime, Meta(tz=True)]]
     automation_name: str
@@ -164,7 +164,7 @@ Y = float
 
 class CalibrationBase(Struct, tag_field="calibration_type", kw_only=True):
     calibration_name: str
-    calibrated_on_pioreactor_unit: str
+    calibrated_on_pioreactor_unit: pt.Unit
     created_at: t.Annotated[datetime, Meta(tz=True)]
     curve_data_: list[float]
     curve_type: str  # ex: "poly"

--- a/pioreactor/types.py
+++ b/pioreactor/types.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import typing as t
 
+# alias types
+Unit = str
+Experiment = str
+
 from msgspec import Meta
 
 if t.TYPE_CHECKING:

--- a/pioreactor/utils/__init__.py
+++ b/pioreactor/utils/__init__.py
@@ -147,8 +147,8 @@ class managed_lifecycle:
 
     def __init__(
         self,
-        unit: str,
-        experiment: str,
+        unit: pt.Unit,
+        experiment: pt.Experiment,
         name: str,
         mqtt_client: Client | None = None,
         exit_on_mqtt_disconnect: bool = False,
@@ -282,8 +282,8 @@ class managed_lifecycle:
 class long_running_managed_lifecycle(managed_lifecycle):
     def __init__(
         self,
-        unit: str,
-        experiment: str,
+        unit: pt.Unit,
+        experiment: pt.Experiment,
         name: str,
         mqtt_client: Client | None = None,
         exit_on_mqtt_disconnect: bool = False,
@@ -677,8 +677,8 @@ class JobManager:
 
     def register_and_set_running(
         self,
-        unit: str,
-        experiment: str,
+        unit: pt.Unit,
+        experiment: pt.Experiment,
         job_name: str,
         job_source: str | None,
         pid: int,
@@ -861,9 +861,9 @@ class ClusterJobManager:
 
     @staticmethod
     def kill_jobs(
-        units: tuple[str, ...],
+        units: tuple[pt.Unit, ...],
         all_jobs: bool = False,
-        experiment: str | None = None,
+        experiment: pt.Experiment | None = None,
         job_name: str | None = None,
         job_source: str | None = None,
         job_id: int | None = None,
@@ -887,7 +887,7 @@ class ClusterJobManager:
             if job_id:
                 params["job_id"] = job_id
 
-        def _thread_function(unit: str) -> tuple[bool, dict]:
+        def _thread_function(unit: pt.Unit) -> tuple[bool, dict]:
             try:
                 r = patch_into(resolve_to_address(unit), endpoint, params=params)
                 r.raise_for_status()

--- a/pioreactor/utils/networking.py
+++ b/pioreactor/utils/networking.py
@@ -11,6 +11,7 @@ from typing import Generator
 from pioreactor.config import config
 from pioreactor.exc import RsyncError
 from pioreactor.exc import SSHError
+from pioreactor import types as pt
 
 
 def ssh(address: str, command: str):
@@ -40,7 +41,7 @@ def rsync(*args: str) -> None:
 
 
 def cp_file_across_cluster(
-    unit: str, localpath: str, remotepath: str, timeout: int = 5, user="pioreactor"
+    unit: pt.Unit, localpath: str, remotepath: str, timeout: int = 5, user="pioreactor"
 ) -> None:
     try:
         rsync(

--- a/pioreactor/utils/streaming.py
+++ b/pioreactor/utils/streaming.py
@@ -23,6 +23,7 @@ from pioreactor.structs import DosingEvent
 from pioreactor.structs import ODReadings
 from pioreactor.structs import RawODReading
 from pioreactor.utils.timing import to_datetime
+from pioreactor import types as pt
 
 
 class ODObservationSource(Protocol):
@@ -50,8 +51,8 @@ class ExportODSource(ODObservationSource):
         self,
         filename: str,
         skip_first: int = 0,
-        pioreactor_unit: str = "$broadcast",
-        experiment="$experiment",
+        pioreactor_unit: pt.Unit = "$broadcast",
+        experiment: pt.Experiment = "$experiment",
     ) -> None:
         self.filename = filename
         self.skip_first = skip_first
@@ -100,8 +101,8 @@ class ExportDosingSource(DosingObservationSource):
         self,
         filename: str | None,
         skip_first: int = 0,
-        pioreactor_unit: str = "$broadcast",
-        experiment="$experiment",
+        pioreactor_unit: pt.Unit = "$broadcast",
+        experiment: pt.Experiment = "$experiment",
     ) -> None:
         self.filename = filename
         self.skip_first = skip_first
@@ -145,7 +146,7 @@ class ExportDosingSource(DosingObservationSource):
 class MqttODSource(ODObservationSource):
     is_live = True
 
-    def __init__(self, unit: str, experiment: str, *, skip_first: int = 0) -> None:
+    def __init__(self, unit: pt.Unit, experiment: pt.Experiment, *, skip_first: int = 0) -> None:
         self.unit, self.experiment, self.skip_first = unit, experiment, skip_first
 
     def __iter__(self):
@@ -167,7 +168,7 @@ class MqttODSource(ODObservationSource):
 class MqttDosingSource(DosingObservationSource):
     is_live = True
 
-    def __init__(self, unit: str, experiment: str) -> None:
+    def __init__(self, unit: pt.Unit, experiment: pt.Experiment) -> None:
         self.unit, self.experiment = unit, experiment
 
     def __iter__(self):

--- a/pioreactor/whoami.py
+++ b/pioreactor/whoami.py
@@ -8,6 +8,7 @@ import warnings
 from functools import cache
 
 from pioreactor import mureq
+from pioreactor import types as pt
 from pioreactor.exc import NotAssignedAnExperimentError
 from pioreactor.exc import NoWorkerFoundError
 from pioreactor.version import version_text_to_tuple
@@ -18,12 +19,12 @@ UNIVERSAL_EXPERIMENT = "$experiment"
 NO_EXPERIMENT = "$no_experiment_present"
 
 
-def get_latest_experiment_name() -> str:
+def get_latest_experiment_name() -> pt.Experiment:
     warnings.warn("Use whoami.get_assigned_experiment_name(unit) instead", DeprecationWarning, stacklevel=2)
     return get_assigned_experiment_name(get_unit_name())
 
 
-def get_testing_experiment_name() -> str:
+def get_testing_experiment_name() -> pt.Experiment:
     try:
         exp = get_assigned_experiment_name(get_unit_name())
         return f"_testing_{exp}"
@@ -31,11 +32,11 @@ def get_testing_experiment_name() -> str:
         return f"_testing_{NO_EXPERIMENT}"
 
 
-def get_assigned_experiment_name(unit_name: str) -> str:
+def get_assigned_experiment_name(unit_name: pt.Unit) -> pt.Experiment:
     return _get_assigned_experiment_name(unit_name)
 
 
-def _get_assigned_experiment_name(unit_name: str) -> str:
+def _get_assigned_experiment_name(unit_name: pt.Unit) -> pt.Experiment:
     from pioreactor.pubsub import get_from_leader
     from pioreactor.config import leader_address
 
@@ -75,7 +76,7 @@ def _get_assigned_experiment_name(unit_name: str) -> str:
         )
 
 
-def is_active(unit_name: str) -> bool:
+def is_active(unit_name: pt.Unit) -> bool:
     if os.environ.get("ACTIVE") == "1" or is_testing_env():
         return True
     elif os.environ.get("ACTIVE") == "0":
@@ -115,7 +116,7 @@ def get_hostname() -> str:
 
 
 @cache
-def get_unit_name() -> str:
+def get_unit_name() -> pt.Unit:
     hostname = get_hostname()
 
     if hostname == "raspberrypi":


### PR DESCRIPTION
## Summary
- define `Unit` and `Experiment` as `str` aliases in `types.py`
- update `whoami.get_unit_name` and related functions to return these aliases
- use new types in several modules such as background job base classes, utils, logging and others

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68548b77cc84832282374ca77f3d9163