### PR TITLE
fix(ui): refetch unit config when AdvancedConfigDialog opens

### DIFF
--- a/frontend/src/components/AdvancedConfigDialog.jsx
+++ b/frontend/src/components/AdvancedConfigDialog.jsx
@@ -26,13 +26,36 @@ function AdvancedConfigDialog({ open, onFinished, jobName, displayName, unit, ex
   const [original, setOriginal] = useState({});          // immutable reference
   const [snackbarOpen, setSnackbarOpen] = useState(false);
 
-  // Reset dialog state every time it is opened or config changes
+  // Reset dialog state every time it is opened. The parent (Pioreactor.jsx)
+  // fetches `/api/config/units/${unit}` once on mount and never refreshes,
+  // so the `config` prop may be stale relative to disk — for example after a
+  // job's own persistence step writes back its current settings on Stop.
+  //
+  // Strategy: seed from the prop synchronously so the dialog renders populated
+  // immediately, then re-fetch in the background and overwrite if the API
+  // returns fresher data. On fetch error the optimistic seed already supplied
+  // a usable form.
   useEffect(() => {
-    if (open) {
-      setValues(config);
-      setOriginal(config);
-    }
-  }, [open, config]);
+    if (!open) return;
+
+    setValues(config);
+    setOriginal(config);
+
+    let cancelled = false;
+    fetch(`/api/config/units/${unit}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled) return;
+        const fresh = data?.[unit]?.[`${jobName}.config`];
+        if (fresh !== undefined) {
+          setValues(fresh);
+          setOriginal(fresh);
+        }
+      })
+      .catch(() => { /* optimistic seed already populated the form */ });
+
+    return () => { cancelled = true; };
+  }, [open, unit, jobName, config]);
 
   const handleClose = () => onFinished();
 


### PR DESCRIPTION
Activities → Advanced screens require a hard refresh to show current data. 

The dialog reads its initial values from the `config` prop populated by the parent `Pioreactor.jsx` via a single mount-time `useEffect` keyed on `[unit]`, so any subsequent write to `config_<unit>.ini` is invisible to the dialog until the user hard-refreshes.

This change moves the source of truth for the dialog's initial state from the parent prop to a fresh fetch keyed on `open`, falling back to the prop on fetch error so behaviour is no worse than before in offline / network-failure conditions.

Possibly related: #606 ("need some way for tasks / sessions to refresh their config without restart web.target")?

**Reproduction (pre-fix):**

1. Install a plugin that writes its `published_settings` back to `config_<unit>.ini` on Stop (our example: https://github.com/amy-bo/electroPioreactor/tree/AEP-Plugin/AEP-Plugin).
2. Open Advanced for that job, type new values, Start, Stop.
3. Re-open Advanced — values revert to whatever was on disk at page load.
4. Hard-refresh — values are correct.

**Verification (post-fix):** Pioreactor v26.3.0 with two consecutive edit-Start-Stop-reopen cycles. Both preserved the user-typed values without hard-refresh.

Produced with Opus 4.7 in https://github.com/Aqueum/Vibe using https://github.com/obra/superpowers systematic-debugging
